### PR TITLE
feat: add three.js engine infrastructure

### DIFF
--- a/src/3d/engine/Loop.ts
+++ b/src/3d/engine/Loop.ts
@@ -1,0 +1,87 @@
+import { Clock } from 'three'
+
+export type TickCallback = (dt: number, elapsed: number) => void
+
+export interface LoopOptions {
+  fixed?: boolean
+  fps?: number
+}
+
+/**
+ * Loop executes registered callbacks using requestAnimationFrame.
+ * Supports fixed or variable timesteps and pause/resume.
+ */
+export class Loop {
+  private readonly clock: Clock
+  private readonly updates: TickCallback[] = []
+  private readonly renders: TickCallback[] = []
+  private running = false
+  private accumulator = 0
+  private readonly fixed: boolean
+  private readonly step: number
+
+  constructor(options: LoopOptions = {}, clock: Clock = new Clock()) {
+    this.clock = clock
+    this.fixed = options.fixed ?? false
+    const fps = options.fps ?? 60
+    this.step = 1 / fps
+  }
+
+  onUpdate(callback: TickCallback): void {
+    this.updates.push(callback)
+  }
+
+  onRender(callback: TickCallback): void {
+    this.renders.push(callback)
+  }
+
+  start(): void {
+    if (this.running)
+      return
+    this.running = true
+    this.clock.start()
+    requestAnimationFrame(this.tick)
+  }
+
+  stop(): void {
+    this.running = false
+  }
+
+  pause(): void {
+    this.stop()
+  }
+
+  resume(): void {
+    if (this.running)
+      return
+    this.running = true
+    this.clock.start()
+    requestAnimationFrame(this.tick)
+  }
+
+  private tick = (): void => {
+    if (!this.running)
+      return
+    const dt = this.clock.getDelta()
+    const elapsed = this.clock.elapsedTime
+
+    if (this.fixed) {
+      this.accumulator += dt
+      while (this.accumulator >= this.step) {
+        for (const update of this.updates)
+          update(this.step, elapsed)
+        for (const render of this.renders)
+          render(this.step, elapsed)
+        this.accumulator -= this.step
+      }
+    }
+    else {
+      for (const update of this.updates)
+        update(dt, elapsed)
+      for (const render of this.renders)
+        render(dt, elapsed)
+    }
+
+    requestAnimationFrame(this.tick)
+  }
+}

--- a/src/3d/engine/ResizeHandler.ts
+++ b/src/3d/engine/ResizeHandler.ts
@@ -1,0 +1,38 @@
+import type { PerspectiveCamera, WebGLRenderer } from 'three'
+
+export interface ResizableEngine {
+  getRenderer: () => WebGLRenderer
+  getCamera: () => PerspectiveCamera
+}
+
+/**
+ * Handles viewport resize and device pixel ratio changes.
+ */
+export class ResizeHandler {
+  private engine?: ResizableEngine
+  private readonly onResize = () => this.resize()
+
+  attach(engine: ResizableEngine): void {
+    this.engine = engine
+    window.addEventListener('resize', this.onResize)
+    this.resize()
+  }
+
+  detach(): void {
+    window.removeEventListener('resize', this.onResize)
+    this.engine = undefined
+  }
+
+  private resize(): void {
+    if (!this.engine)
+      return
+    const renderer = this.engine.getRenderer()
+    const camera = this.engine.getCamera()
+    const width = window.innerWidth
+    const height = window.innerHeight
+    renderer.setSize(width, height)
+    renderer.setPixelRatio(Math.min(2, window.devicePixelRatio))
+    camera.aspect = width / height
+    camera.updateProjectionMatrix()
+  }
+}

--- a/src/3d/engine/cameras/MainCamera.ts
+++ b/src/3d/engine/cameras/MainCamera.ts
@@ -1,0 +1,27 @@
+import { PerspectiveCamera, Vector3 } from 'three'
+
+export interface MainCameraOptions {
+  fov?: number
+  near?: number
+  far?: number
+  position?: Vector3
+  target?: Vector3
+}
+
+/**
+ * Creates the primary perspective camera.
+ */
+export function createMainCamera(options: MainCameraOptions = {}): PerspectiveCamera {
+  const {
+    fov = 60,
+    near = 0.1,
+    far = 2000,
+    position = new Vector3(6, 6, 6),
+    target = new Vector3(0, 0, 0),
+  } = options
+
+  const camera = new PerspectiveCamera(fov, 1, near, far)
+  camera.position.copy(position)
+  camera.lookAt(target)
+  return camera
+}

--- a/src/3d/engine/lights/DefaultLights.ts
+++ b/src/3d/engine/lights/DefaultLights.ts
@@ -1,0 +1,29 @@
+import type { Group, Scene } from 'three'
+import {
+  AmbientLight,
+  DirectionalLight,
+  DirectionalLightHelper,
+} from 'three'
+
+export interface DefaultLightsOptions {
+  helpers?: Group
+}
+
+/**
+ * Adds default ambient and directional lights.
+ */
+export function createDefaultLights(scene: Scene, options: DefaultLightsOptions = {}): void {
+  const { helpers } = options
+
+  const ambient = new AmbientLight(0xFFFFFF, 0.5)
+  const directional = new DirectionalLight(0xFFFFFF, 1)
+  directional.position.set(5, 10, 5)
+  directional.castShadow = true
+  directional.shadow.mapSize.set(1024, 1024)
+
+  scene.add(ambient)
+  scene.add(directional)
+
+  if (helpers)
+    helpers.add(new DirectionalLightHelper(directional, 1))
+}

--- a/src/3d/loaders/loading.ts
+++ b/src/3d/loaders/loading.ts
@@ -1,0 +1,38 @@
+import type { LoaderConstructor } from '~/types/three-ext'
+import { LoadingManager } from 'three'
+
+/**
+ * Creates a shared LoadingManager with basic logging callbacks.
+ */
+export function createLoadingManager(): LoadingManager {
+  const manager = new LoadingManager()
+  manager.onStart = (url, loaded, total) => {
+    console.warn(`Loading started: ${url} (${loaded}/${total})`)
+  }
+  manager.onProgress = (url, loaded, total) => {
+    console.warn(`Loading: ${url} (${loaded}/${total})`)
+  }
+  manager.onError = (url) => {
+    console.error(`Error loading ${url}`)
+  }
+  return manager
+}
+
+/**
+ * Generic loader utility using the shared LoadingManager.
+ */
+export function useLoader<T>(
+  LoaderCtor: LoaderConstructor<T>,
+  url: string,
+  manager: LoadingManager,
+): Promise<T> {
+  const loader = new LoaderCtor(manager)
+  return new Promise<T>((resolve, reject) => {
+    loader.load(
+      url,
+      data => resolve(data as T),
+      undefined,
+      error => reject(error),
+    )
+  })
+}

--- a/src/3d/scene/createBaseScene.ts
+++ b/src/3d/scene/createBaseScene.ts
@@ -1,0 +1,37 @@
+import type { Group, Scene } from 'three'
+import {
+  AxesHelper,
+  BoxGeometry,
+  Mesh,
+  MeshStandardMaterial,
+  PlaneGeometry,
+} from 'three'
+
+export interface BaseSceneOptions {
+  helpers?: Group
+}
+
+/**
+ * Populates the scene with a basic ground and cube.
+ */
+export function createBaseScene(scene: Scene, options: BaseSceneOptions = {}): void {
+  const { helpers } = options
+
+  const groundGeo = new PlaneGeometry(50, 50)
+  const groundMat = new MeshStandardMaterial({ color: 0x808080 })
+  const ground = new Mesh(groundGeo, groundMat)
+  ground.rotation.x = -Math.PI / 2
+  ground.receiveShadow = true
+  scene.add(ground)
+
+  const cubeGeo = new BoxGeometry(1, 1, 1)
+  const cubeMat = new MeshStandardMaterial({ color: 0xCCCCCC })
+  const cube = new Mesh(cubeGeo, cubeMat)
+  cube.position.set(0, 0.5, 0)
+  cube.castShadow = true
+  scene.add(cube)
+
+  if (helpers) {
+    helpers.add(new AxesHelper(5))
+  }
+}

--- a/src/3d/utils/dispose.ts
+++ b/src/3d/utils/dispose.ts
@@ -1,0 +1,42 @@
+import type {
+  Material,
+  Object3D,
+  Texture,
+  WebGLRenderer,
+} from 'three'
+
+function disposeMaterial(material: Material): void {
+  const entries = Object.values(material) as unknown[]
+  for (const value of entries) {
+    if (value && typeof value === 'object' && 'dispose' in value)
+      (value as Texture).dispose()
+  }
+  material.dispose()
+}
+
+/**
+ * Recursively disposes geometries, materials and textures in an Object3D tree.
+ */
+export function disposeObject3D(root: Object3D): void {
+  root.traverse((obj) => {
+    const mesh = obj as unknown as {
+      geometry?: { dispose: () => void }
+      material?: Material | Material[]
+    }
+    if (mesh.geometry)
+      mesh.geometry.dispose()
+    const material = mesh.material
+    if (Array.isArray(material))
+      material.forEach(disposeMaterial)
+    else if (material)
+      disposeMaterial(material)
+  })
+}
+
+/**
+ * Disposes renderer resources.
+ */
+export function disposeRenderer(renderer: WebGLRenderer): void {
+  renderer.renderLists.dispose()
+  renderer.dispose()
+}

--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -80,6 +80,7 @@ declare global {
   const preferredDark: typeof import('./composables/dark')['preferredDark']
   const provide: typeof import('vue')['provide']
   const provideLocal: typeof import('@vueuse/core')['provideLocal']
+  const provideThreeEngine: typeof import('./composables/useThreeEngine')['provideThreeEngine']
   const reactify: typeof import('@vueuse/core')['reactify']
   const reactifyObject: typeof import('@vueuse/core')['reactifyObject']
   const reactive: typeof import('vue')['reactive']
@@ -266,6 +267,7 @@ declare global {
   const useTextDirection: typeof import('@vueuse/core')['useTextDirection']
   const useTextSelection: typeof import('@vueuse/core')['useTextSelection']
   const useTextareaAutosize: typeof import('@vueuse/core')['useTextareaAutosize']
+  const useThreeEngine: typeof import('./composables/useThreeEngine')['useThreeEngine']
   const useThrottle: typeof import('@vueuse/core')['useThrottle']
   const useThrottleFn: typeof import('@vueuse/core')['useThrottleFn']
   const useThrottledRefHistory: typeof import('@vueuse/core')['useThrottledRefHistory']
@@ -395,6 +397,7 @@ declare module 'vue' {
     readonly preferredDark: UnwrapRef<typeof import('./composables/dark')['preferredDark']>
     readonly provide: UnwrapRef<typeof import('vue')['provide']>
     readonly provideLocal: UnwrapRef<typeof import('@vueuse/core')['provideLocal']>
+    readonly provideThreeEngine: UnwrapRef<typeof import('./composables/useThreeEngine')['provideThreeEngine']>
     readonly reactify: UnwrapRef<typeof import('@vueuse/core')['reactify']>
     readonly reactifyObject: UnwrapRef<typeof import('@vueuse/core')['reactifyObject']>
     readonly reactive: UnwrapRef<typeof import('vue')['reactive']>
@@ -581,6 +584,7 @@ declare module 'vue' {
     readonly useTextDirection: UnwrapRef<typeof import('@vueuse/core')['useTextDirection']>
     readonly useTextSelection: UnwrapRef<typeof import('@vueuse/core')['useTextSelection']>
     readonly useTextareaAutosize: UnwrapRef<typeof import('@vueuse/core')['useTextareaAutosize']>
+    readonly useThreeEngine: UnwrapRef<typeof import('./composables/useThreeEngine')['useThreeEngine']>
     readonly useThrottle: UnwrapRef<typeof import('@vueuse/core')['useThrottle']>
     readonly useThrottleFn: UnwrapRef<typeof import('@vueuse/core')['useThrottleFn']>
     readonly useThrottledRefHistory: UnwrapRef<typeof import('@vueuse/core')['useThrottledRefHistory']>

--- a/src/components/three-canvas/index.vue
+++ b/src/components/three-canvas/index.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { GameEngine } from '~/3d/engine/GameEngine'
+
+const props = defineProps<{
+  antialias?: boolean
+  background?: string | number
+  showHelpers?: boolean
+}>()
+const canvasEl = ref<HTMLCanvasElement | null>(null)
+let engine: GameEngine | undefined
+
+onMounted(() => {
+  if (!canvasEl.value)
+    return
+  engine = new GameEngine({
+    canvas: canvasEl.value,
+    width: canvasEl.value.clientWidth || window.innerWidth,
+    height: canvasEl.value.clientHeight || window.innerHeight,
+    antialias: props.antialias,
+    background: props.background,
+    showHelpers: props.showHelpers,
+  })
+  provideThreeEngine(engine)
+  engine.start()
+})
+
+onBeforeUnmount(() => {
+  engine?.dispose()
+})
+</script>
+
+<template>
+  <canvas ref="canvasEl" class="three-canvas" />
+</template>
+
+<style src="~/styles/three.css"></style>

--- a/src/composables/useThreeEngine.ts
+++ b/src/composables/useThreeEngine.ts
@@ -1,0 +1,20 @@
+import type { GameEngine } from '~/3d/engine/GameEngine'
+
+const THREE_ENGINE_KEY = Symbol('ThreeEngine') as InjectionKey<GameEngine>
+
+/**
+ * Provides a GameEngine instance to the Vue component tree.
+ */
+export function provideThreeEngine(engine: GameEngine): void {
+  provide(THREE_ENGINE_KEY, engine)
+}
+
+/**
+ * Injects the GameEngine instance.
+ */
+export function useThreeEngine(): GameEngine {
+  const engine = inject(THREE_ENGINE_KEY)
+  if (!engine)
+    throw new Error('GameEngine instance not provided')
+  return engine
+}

--- a/src/dev/DebugOverlay.vue
+++ b/src/dev/DebugOverlay.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+const engine = useThreeEngine()
+const paused = ref(false)
+const helpersVisible = ref(true)
+
+function togglePause(): void {
+  if (paused.value) {
+    engine.start()
+  }
+  else {
+    engine.stop()
+  }
+  paused.value = !paused.value
+}
+
+function toggleHelpers(): void {
+  helpersVisible.value = !helpersVisible.value
+  engine.setHelpersVisible(helpersVisible.value)
+}
+
+const fps = ref(0)
+let last = performance.now()
+let frames = 0
+function measure(now: number): void {
+  frames++
+  if (now > last + 1000) {
+    fps.value = frames
+    frames = 0
+    last = now
+  }
+  requestAnimationFrame(measure)
+}
+requestAnimationFrame(measure)
+</script>
+
+<template>
+  <div class="debug-overlay">
+    <button @click="togglePause">
+      {{ paused ? 'Resume' : 'Pause' }}
+    </button>
+    <button @click="toggleHelpers">
+      Helpers
+    </button>
+    <span>{{ fps }} FPS</span>
+  </div>
+</template>
+
+<style scoped>
+.debug-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  padding: 8px;
+  color: white;
+  z-index: 1000;
+}
+
+button {
+  margin-right: 4px;
+}
+</style>

--- a/src/pages/three-demo.vue
+++ b/src/pages/three-demo.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import DebugOverlay from '~/dev/DebugOverlay.vue'
+
+const showDebug = import.meta.env.DEV
+</script>
+
+<template>
+  <ThreeCanvas background="#0e0e12" :show-helpers="true" />
+  <DebugOverlay v-if="showDebug" />
+</template>

--- a/src/styles/three.css
+++ b/src/styles/three.css
@@ -1,0 +1,6 @@
+.three-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  outline: 0;
+}

--- a/src/types/three-ext.d.ts
+++ b/src/types/three-ext.d.ts
@@ -1,0 +1,16 @@
+/* eslint-disable */
+import type { Loader, LoadingManager } from 'three'
+
+/**
+ * Constructor type for Three.js loaders returning data of type `T`.
+ */
+export type LoaderConstructor<T, TLoader extends Loader = Loader> = new (
+  manager: LoadingManager,
+) => TLoader & {
+  load: (
+    url: string,
+    onLoad: (data: T) => void,
+    onProgress?: (event: ProgressEvent<EventTarget>) => void,
+    onError?: (err: unknown) => void,
+  ) => void;
+};

--- a/test/game-engine.test.ts
+++ b/test/game-engine.test.ts
@@ -1,0 +1,34 @@
+import * as THREE from 'three'
+import { describe, expect, it, vi } from 'vitest'
+import { GameEngine } from '~/3d/engine/GameEngine'
+
+class WebGLRendererStub {
+  domElement = document.createElement('canvas')
+  shadowMap = { enabled: false, type: THREE.PCFSoftShadowMap }
+  renderLists = { dispose: vi.fn() }
+  setSize = vi.fn()
+  setPixelRatio = vi.fn()
+  setClearColor = vi.fn()
+  render = vi.fn()
+  dispose = vi.fn()
+  physicallyCorrectLights = false
+  outputColorSpace = THREE.SRGBColorSpace
+  toneMapping = THREE.ACESFilmicToneMapping
+}
+
+describe('game engine', () => {
+  it('instantiates and disposes without errors', () => {
+    const original = THREE.WebGLRenderer
+    Object.defineProperty(THREE, 'WebGLRenderer', {
+      configurable: true,
+      value: WebGLRendererStub,
+    })
+    const canvas = document.createElement('canvas')
+    const engine = new GameEngine({ canvas, width: 100, height: 100 })
+    engine.start()
+    engine.dispose()
+    const renderer = engine.getRenderer() as unknown as WebGLRendererStub
+    expect(renderer.dispose).toHaveBeenCalled()
+    Object.defineProperty(THREE, 'WebGLRenderer', { value: original })
+  })
+})

--- a/test/resize-handler.test.ts
+++ b/test/resize-handler.test.ts
@@ -1,0 +1,30 @@
+import type { PerspectiveCamera, WebGLRenderer } from 'three'
+import { describe, expect, it, vi } from 'vitest'
+import { ResizeHandler } from '~/3d/engine/ResizeHandler'
+
+describe('resize handler', () => {
+  it('updates renderer size and camera aspect', () => {
+    const setSize = vi.fn()
+    const setPixelRatio = vi.fn()
+    const renderer = { setSize, setPixelRatio } as unknown as WebGLRenderer
+    const camera = { aspect: 1, updateProjectionMatrix: vi.fn() } as unknown as PerspectiveCamera
+    const engine = {
+      getRenderer: () => renderer,
+      getCamera: () => camera,
+    }
+
+    const handler = new ResizeHandler()
+    handler.attach(engine)
+
+    ;(window as unknown as { innerWidth: number }).innerWidth = 800
+    ;(window as unknown as { innerHeight: number }).innerHeight = 600
+    window.dispatchEvent(new Event('resize'))
+
+    expect(setSize).toHaveBeenCalledWith(800, 600)
+    expect(setPixelRatio).toHaveBeenCalled()
+    expect(camera.aspect).toBeCloseTo(800 / 600)
+    expect(camera.updateProjectionMatrix).toHaveBeenCalled()
+
+    handler.detach()
+  })
+})


### PR DESCRIPTION
## Summary
- scaffold a typed Three.js engine with resize and animation loop
- expose Vue canvas component and engine provider
- add basic scene, lights, loaders, and tests

## Testing
- `pnpm lint` *(fails: eslint errors across repository)*
- `pnpm typecheck`
- `pnpm test` *(fails: missing component and WebGL renderer spy limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68b803c642c4832a9d84156f448701f6