### PR TITLE
Add English locale and fix ThreeEngine injection

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,14 @@
+button:
+  about: About
+  back: Back
+  go: Try
+  home: Home
+  toggle_dark: Toggle dark mode
+  toggle_langs: Change languages
+intro:
+  desc: Vite app example
+  dynamic-route: Dynamic route demo
+  hi: Hi, {name}!
+  aka: Also known as
+  whats-your-name: What's your name?
+not-found: Page not found

--- a/src/components/three-canvas/index.vue
+++ b/src/components/three-canvas/index.vue
@@ -30,7 +30,10 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <canvas ref="canvasEl" class="three-canvas" />
+  <div class="three-canvas-container">
+    <canvas ref="canvasEl" class="three-canvas" />
+    <slot />
+  </div>
 </template>
 
 <style src="~/styles/three.css"></style>

--- a/src/modules/i18n.ts
+++ b/src/modules/i18n.ts
@@ -19,7 +19,7 @@ const localesMap = Object.fromEntries(
 
 export const availableLocales = Object.keys(localesMap)
 
-const loadedLanguages: string[] = []
+const loadedLanguages: Locale[] = []
 
 function setI18nLanguage(lang: Locale) {
   i18n.global.locale.value = lang as any
@@ -28,17 +28,18 @@ function setI18nLanguage(lang: Locale) {
   return lang
 }
 
-export async function loadLanguageAsync(lang: string): Promise<Locale> {
-  // If the same language
+export async function loadLanguageAsync(lang: Locale): Promise<Locale> {
   if (i18n.global.locale.value === lang)
     return setI18nLanguage(lang)
 
-  // If the language was already loaded
   if (loadedLanguages.includes(lang))
     return setI18nLanguage(lang)
 
-  // If the language hasn't been loaded yet
-  const messages = await localesMap[lang]()
+  const loader = localesMap[lang]
+  if (!loader)
+    throw new Error(`Locale "${lang}" is not available`)
+
+  const messages = await loader()
   i18n.global.setLocaleMessage(lang, messages.default)
   loadedLanguages.push(lang)
   return setI18nLanguage(lang)

--- a/src/pages/three-demo.vue
+++ b/src/pages/three-demo.vue
@@ -5,6 +5,7 @@ const showDebug = import.meta.env.DEV
 </script>
 
 <template>
-  <ThreeCanvas background="#0e0e12" :show-helpers="true" />
-  <DebugOverlay v-if="showDebug" />
+  <ThreeCanvas background="#0e0e12" :show-helpers="true">
+    <DebugOverlay v-if="showDebug" />
+  </ThreeCanvas>
 </template>

--- a/src/styles/three.css
+++ b/src/styles/three.css
@@ -1,3 +1,9 @@
+.three-canvas-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
 .three-canvas {
   display: block;
   width: 100%;


### PR DESCRIPTION
## Summary
- add defensive locale loader and English translations
- expose ThreeEngine to debug overlay via canvas slot

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b81e12e344832abc388632a3823a0a