### PR TITLE
Render overlay after Three engine ready

### DIFF
--- a/src/components/three-canvas/index.vue
+++ b/src/components/three-canvas/index.vue
@@ -8,6 +8,8 @@ const props = defineProps<{
 }>()
 const canvasEl = ref<HTMLCanvasElement | null>(null)
 let engine: GameEngine | undefined
+// Flag indicating when the Three.js engine is ready so child content can render.
+const isReady = ref<boolean>(false)
 
 onMounted(() => {
   if (!canvasEl.value)
@@ -22,6 +24,7 @@ onMounted(() => {
   })
   provideThreeEngine(engine)
   engine.start()
+  isReady.value = true
 })
 
 onBeforeUnmount(() => {
@@ -32,7 +35,7 @@ onBeforeUnmount(() => {
 <template>
   <div class="three-canvas-container">
     <canvas ref="canvasEl" class="three-canvas" />
-    <slot />
+    <slot v-if="isReady" />
   </div>
 </template>
 

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -5,8 +5,9 @@ const showDebug = import.meta.env.DEV
 </script>
 
 <template>
-  <ThreeCanvas background="#0e0e12" :show-helpers="true" />
-  <DebugOverlay v-if="showDebug" />
+  <ThreeCanvas background="#0e0e12" :show-helpers="true">
+    <DebugOverlay v-if="showDebug" />
+  </ThreeCanvas>
 </template>
 
 <route lang="yaml">


### PR DESCRIPTION
## Summary
- track engine readiness inside ThreeCanvas and expose slot only when initialized
- move DebugOverlay into ThreeCanvas so it renders after engine start

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@antfu/eslint-config')*

------
https://chatgpt.com/codex/tasks/task_e_68b823681fb4832a8d711a2469de1ea9