### PR TITLE
Ensure GameEngine reattaches listeners after restart

### DIFF
--- a/test/game-engine.test.ts
+++ b/test/game-engine.test.ts
@@ -1,34 +1,73 @@
-import * as THREE from 'three'
 import { describe, expect, it, vi } from 'vitest'
 import { GameEngine } from '~/3d/engine/GameEngine'
 
-class WebGLRendererStub {
-  domElement = document.createElement('canvas')
-  shadowMap = { enabled: false, type: THREE.PCFSoftShadowMap }
-  renderLists = { dispose: vi.fn() }
-  setSize = vi.fn()
-  setPixelRatio = vi.fn()
-  setClearColor = vi.fn()
-  render = vi.fn()
-  dispose = vi.fn()
-  physicallyCorrectLights = false
-  outputColorSpace = THREE.SRGBColorSpace
-  toneMapping = THREE.ACESFilmicToneMapping
-}
+vi.mock('three', async () => {
+  const actual = await vi.importActual<typeof import('three')>('three')
+  class WebGLRendererStub {
+    domElement = document.createElement('canvas')
+    shadowMap = { enabled: false, type: actual.PCFSoftShadowMap }
+    renderLists = { dispose: vi.fn() }
+    setSize = vi.fn()
+    setPixelRatio = vi.fn()
+    setClearColor = vi.fn()
+    render = vi.fn()
+    dispose = vi.fn()
+    physicallyCorrectLights = false
+    outputColorSpace = actual.SRGBColorSpace
+    toneMapping = actual.ACESFilmicToneMapping
+  }
+  return { ...actual, WebGLRenderer: WebGLRendererStub }
+})
 
 describe('game engine', () => {
   it('instantiates and disposes without errors', () => {
-    const original = THREE.WebGLRenderer
-    Object.defineProperty(THREE, 'WebGLRenderer', {
-      configurable: true,
-      value: WebGLRendererStub,
-    })
     const canvas = document.createElement('canvas')
     const engine = new GameEngine({ canvas, width: 100, height: 100 })
     engine.start()
     engine.dispose()
-    const renderer = engine.getRenderer() as unknown as WebGLRendererStub
+    const renderer = engine.getRenderer() as unknown as { dispose: ReturnType<typeof vi.fn> }
     expect(renderer.dispose).toHaveBeenCalled()
-    Object.defineProperty(THREE, 'WebGLRenderer', { value: original })
+  })
+
+  it('reattaches resize and visibility listeners after restart', () => {
+    const raf = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(() => 0)
+    const canvas = document.createElement('canvas')
+    const engine = new GameEngine({ canvas, width: 100, height: 100 })
+
+    engine.start()
+    engine.stop()
+
+    const renderer = engine.getRenderer() as unknown as { setSize: ReturnType<typeof vi.fn>, setPixelRatio: ReturnType<typeof vi.fn> }
+    const loop = (engine as unknown as { loop: { pause: () => void, resume: () => void } }).loop
+    const pauseSpy = vi.spyOn(loop, 'pause')
+    const resumeSpy = vi.spyOn(loop, 'resume')
+
+    engine.start()
+
+    renderer.setSize.mockClear()
+    renderer.setPixelRatio.mockClear()
+    pauseSpy.mockClear()
+    resumeSpy.mockClear()
+
+    ;(window as unknown as { innerWidth: number }).innerWidth = 200
+    ;(window as unknown as { innerHeight: number }).innerHeight = 150
+    window.dispatchEvent(new Event('resize'))
+
+    expect(renderer.setSize).toHaveBeenCalledWith(200, 150)
+    expect(renderer.setPixelRatio).toHaveBeenCalled()
+
+    const hiddenDescriptor = Object.getOwnPropertyDescriptor(document, 'hidden')
+    Object.defineProperty(document, 'hidden', { configurable: true, value: true })
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(pauseSpy).toHaveBeenCalledTimes(1)
+    Object.defineProperty(document, 'hidden', { configurable: true, value: false })
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(resumeSpy).toHaveBeenCalledTimes(1)
+    if (hiddenDescriptor)
+      Object.defineProperty(document, 'hidden', hiddenDescriptor)
+
+    raf.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary
- Reattach `visibilitychange` and resize listeners whenever the engine starts
- Reset engine state on `stop()` to enable clean restarts
- Add regression test ensuring resize and visibility listeners survive a stop/start cycle

## Testing
- `npx vitest run test/game-engine.test.ts test/resize-handler.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b828daa464832a8410584a4d5c7f5e