### PR TITLE
feat: introduce input engine

### DIFF
--- a/src/config/input.defaults.ts
+++ b/src/config/input.defaults.ts
@@ -1,0 +1,34 @@
+import { Action } from '~/engines/input/types'
+
+export const defaultInputBindings: Record<'keyboardMouse' | 'gamepad' | 'mobile', Record<Action, readonly string[]>> = {
+  keyboardMouse: {
+    [Action.MoveForward]: ['KeyW', 'ArrowUp'],
+    [Action.MoveBackward]: ['KeyS', 'ArrowDown'],
+    [Action.MoveLeft]: ['KeyA', 'ArrowLeft'],
+    [Action.MoveRight]: ['KeyD', 'ArrowRight'],
+    [Action.Jump]: ['Space'],
+    [Action.Primary]: ['Mouse0'],
+    [Action.Secondary]: ['Mouse1'],
+    [Action.Pause]: ['Escape'],
+  },
+  gamepad: {
+    [Action.MoveForward]: ['AxisLeftY-'],
+    [Action.MoveBackward]: ['AxisLeftY+'],
+    [Action.MoveLeft]: ['AxisLeftX-'],
+    [Action.MoveRight]: ['AxisLeftX+'],
+    [Action.Jump]: ['Button0'],
+    [Action.Primary]: ['Button0'],
+    [Action.Secondary]: ['Button1'],
+    [Action.Pause]: ['Button9'],
+  },
+  mobile: {
+    [Action.MoveForward]: ['swipe-up'],
+    [Action.MoveBackward]: ['swipe-down'],
+    [Action.MoveLeft]: ['swipe-left'],
+    [Action.MoveRight]: ['swipe-right'],
+    [Action.Jump]: ['tap-hold'],
+    [Action.Primary]: ['tap'],
+    [Action.Secondary]: ['double-tap'],
+    [Action.Pause]: ['two-finger-tap'],
+  },
+}

--- a/src/engines/input/InputEngine.ts
+++ b/src/engines/input/InputEngine.ts
@@ -1,0 +1,89 @@
+import { Action, InputSource, type InputState } from './types'
+
+/**
+ * Coordinates multiple {@link InputSource}s and exposes immutable snapshots
+ * of the current input state each frame.
+ */
+export class InputEngine {
+  private readonly actions: Record<Action, boolean>
+  private readonly listeners: Map<Action, Set<(pressed: boolean) => void>> = new Map()
+  private readonly sources = new Set<InputSource>()
+  private running = false
+
+  constructor() {
+    this.actions = this.createDefaultActionState()
+  }
+
+  /** Start all registered input sources. */
+  start(): void {
+    if (this.running)
+      return
+    this.running = true
+    for (const source of this.sources)
+      source.start(this.handleInput)
+  }
+
+  /** Stop all registered input sources. */
+  stop(): void {
+    if (!this.running)
+      return
+    this.running = false
+    for (const source of this.sources)
+      source.stop()
+  }
+
+  /**
+   * Returns an immutable snapshot of the current input state.
+   * Each call produces a new frozen object to avoid shared mutations.
+   */
+  snapshot(): InputState {
+    const actions = Object.freeze({ ...this.actions }) as Readonly<Record<Action, boolean>>
+    return Object.freeze({ actions })
+  }
+
+  /**
+   * Register a callback fired when the specified action changes.
+   * Returns a function that removes the listener.
+   */
+  onAction(action: Action, callback: (pressed: boolean) => void): () => void {
+    let set = this.listeners.get(action)
+    if (!set) {
+      set = new Set()
+      this.listeners.set(action, set)
+    }
+    set.add(callback)
+    return () => {
+      set!.delete(callback)
+      if (set!.size === 0)
+        this.listeners.delete(action)
+    }
+  }
+
+  /**
+   * Registers an {@link InputSource}. If the engine is already running the
+   * source is immediately started.
+   */
+  registerSource(source: InputSource): void {
+    this.sources.add(source)
+    if (this.running)
+      source.start(this.handleInput)
+  }
+
+  private readonly handleInput = (action: Action, pressed: boolean): void => {
+    if (this.actions[action] === pressed)
+      return
+    this.actions[action] = pressed
+    const listeners = this.listeners.get(action)
+    if (listeners) {
+      for (const listener of listeners)
+        listener(pressed)
+    }
+  }
+
+  private createDefaultActionState(): Record<Action, boolean> {
+    const state: Record<Action, boolean> = {} as Record<Action, boolean>
+    for (const action of Object.values(Action))
+      state[action] = false
+    return state
+  }
+}

--- a/src/engines/input/README.md
+++ b/src/engines/input/README.md
@@ -1,0 +1,30 @@
+# Input Engine
+
+The input engine normalises signals from multiple devices (keyboard, gamepad,
+mobile gestures...) into a consistent set of actions. Each frame the engine
+produces an immutable snapshot of the current state allowing systems to safely
+read inputs without risk of mutation.
+
+## Flow
+
+```
++-------------+      +---------------+      +-----------------+
+| InputSource | ---> | Input Engine  | ---> | Game Systems    |
++-------------+      +---------------+      +-----------------+
+```
+
+1. **Sources** translate raw device events into high level {@link Action} values.
+2. The **engine** aggregates these events, updates its internal state and
+   notifies listeners registered via `onAction`.
+3. Systems call `snapshot()` every frame to obtain a frozen
+   {@link InputState} object representing the current actions.
+
+## API
+
+- `start()` / `stop()` — control all registered sources.
+- `snapshot()` — returns the current immutable {@link InputState}.
+- `onAction(action, cb)` — observe transitions for a specific action.
+- `registerSource(source)` — plug in a new device input translator.
+
+Sources are intentionally decoupled from the engine so new devices can be
+supported without modifying existing logic.

--- a/src/engines/input/types.ts
+++ b/src/engines/input/types.ts
@@ -1,0 +1,27 @@
+export enum Action {
+  MoveForward = 'move-forward',
+  MoveBackward = 'move-backward',
+  MoveLeft = 'move-left',
+  MoveRight = 'move-right',
+  Jump = 'jump',
+  Primary = 'primary',
+  Secondary = 'secondary',
+  Pause = 'pause',
+}
+
+/**
+ * Immutable snapshot of the user's input for a single frame.
+ * All values are boolean flags describing the active state of each action.
+ */
+export interface InputState {
+  readonly actions: Readonly<Record<Action, boolean>>;
+}
+
+/**
+ * An input source translates raw device events into high-level actions.
+ * Sources are expected to emit action changes via the provided callback.
+ */
+export interface InputSource {
+  start(emit: (action: Action, pressed: boolean) => void): void;
+  stop(): void;
+}

--- a/test/input-engine.test.ts
+++ b/test/input-engine.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+import { InputEngine } from '~/engines/input/InputEngine'
+import { Action, type InputSource } from '~/engines/input/types'
+
+describe('InputEngine', () => {
+  class MockSource implements InputSource {
+    private emit: ((action: Action, pressed: boolean) => void) | null = null
+    start(emit: (action: Action, pressed: boolean) => void): void {
+      this.emit = emit
+    }
+    stop(): void {
+      this.emit = null
+    }
+    trigger(action: Action, pressed: boolean): void {
+      this.emit?.(action, pressed)
+    }
+  }
+
+  it('produces immutable snapshots', () => {
+    const engine = new InputEngine()
+    const source = new MockSource()
+    engine.registerSource(source)
+    engine.start()
+    source.trigger(Action.Jump, true)
+    const snap = engine.snapshot()
+    expect(snap.actions[Action.Jump]).toBe(true)
+    expect(Object.isFrozen(snap)).toBe(true)
+    expect(Object.isFrozen(snap.actions)).toBe(true)
+    expect(() => {
+      ;(snap.actions as any)[Action.Jump] = false
+    }).toThrow()
+    const next = engine.snapshot()
+    expect(next.actions[Action.Jump]).toBe(true)
+  })
+
+  it('notifies listeners on action change', () => {
+    const engine = new InputEngine()
+    const source = new MockSource()
+    engine.registerSource(source)
+    const listener = vi.fn()
+    engine.onAction(Action.Primary, listener)
+    engine.start()
+    source.trigger(Action.Primary, true)
+    expect(listener).toHaveBeenCalledWith(true)
+  })
+})


### PR DESCRIPTION
## Summary
- add input engine with actions, sources and snapshot support
- provide default input bindings for common devices
- document input engine architecture and add unit tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68b83ac8cb98832a986ad816f0c2b511