### PR TITLE
feat(input): add utility helpers

### DIFF
--- a/src/engines/input/utils.ts
+++ b/src/engines/input/utils.ts
@@ -1,0 +1,131 @@
+/**
+ * Utility helpers for input processing.
+ *
+ * Each function is stateless and side-effect free to ease testing and reuse.
+ */
+
+/**
+ * Restrict a number to the inclusive `[min, max]` range.
+ *
+ * @param value - Number to clamp.
+ * @param min - Lower bound.
+ * @param max - Upper bound.
+ * @returns Clamped number.
+ * @throws {RangeError} If `min` is greater than `max`.
+ */
+export function clamp(value: number, min: number, max: number): number {
+  if (min > max)
+    throw new RangeError('clamp: min must be less than or equal to max')
+  if (value < min)
+    return min
+  if (value > max)
+    return max
+  return value
+}
+
+/** Result of a {@link smoothDamp} calculation. */
+export interface SmoothDampResult {
+  /** New value after damping. */
+  readonly value: number
+  /** Updated velocity to be used for the next step. */
+  readonly velocity: number
+}
+
+/**
+ * Gradually changes a value towards a desired goal over time.
+ *
+ * The function emulates critically damped spring motion and never overshoots
+ * the target. The returned velocity should be persisted and passed back on the
+ * next call.
+ *
+ * @param current - Current value.
+ * @param target - Target value to reach.
+ * @param currentVelocity - Current velocity; typically persisted between calls.
+ * @param smoothTime - Time the value should take to reach the target. Must be positive.
+ * @param deltaTime - Time step of this update. Must be non-negative.
+ * @param maxSpeed - Optional speed cap. Defaults to `Infinity`.
+ * @returns New value and velocity.
+ */
+export function smoothDamp(
+  current: number,
+  target: number,
+  currentVelocity: number,
+  smoothTime: number,
+  deltaTime: number,
+  maxSpeed: number = Number.POSITIVE_INFINITY,
+): SmoothDampResult {
+  if (smoothTime <= 0)
+    throw new RangeError('smoothDamp: smoothTime must be greater than 0')
+  if (deltaTime < 0)
+    throw new RangeError('smoothDamp: deltaTime must be non-negative')
+
+  const omega = 2 / smoothTime
+  const x = omega * deltaTime
+  const exp = 1 / (1 + x + 0.48 * x * x + 0.235 * x * x * x)
+
+  let change = current - target
+  const originalTo = target
+
+  const maxChange = maxSpeed * smoothTime
+  change = clamp(change, -maxChange, maxChange)
+  target = current - change
+
+  let temp = (currentVelocity + omega * change) * deltaTime
+  let newVelocity = (currentVelocity - omega * temp) * exp
+  let newValue = target + (change + temp) * exp
+
+  // Prevent overshooting.
+  if ((originalTo - current > 0) === (newValue > originalTo)) {
+    newValue = originalTo
+    newVelocity = (newValue - originalTo) / deltaTime
+  }
+
+  return { value: newValue, velocity: newVelocity }
+}
+
+/**
+ * Apply an analog deadzone to a value between `-1` and `1`.
+ *
+ * Values within the deadzone return `0`. Remaining values are rescaled so the
+ * output preserves full sensitivity outside the deadzone.
+ *
+ * @param value - Input value.
+ * @param deadzone - Deadzone radius in the range `[0, 1)`. Defaults to `0`.
+ * @returns Adjusted value.
+ * @throws {RangeError} If `deadzone` is outside `[0, 1)`.
+ */
+export function applyDeadzone(value: number, deadzone: number = 0): number {
+  if (deadzone < 0 || deadzone >= 1)
+    throw new RangeError('applyDeadzone: deadzone must be in [0, 1)')
+
+  const abs = Math.abs(value)
+  if (abs <= deadzone)
+    return 0
+  const sign = Math.sign(value)
+  return sign * ((abs - deadzone) / (1 - deadzone))
+}
+
+/** Possible keyboard layout hints. */
+export type LayoutHint = 'qwerty' | 'azerty' | 'qwertz'
+
+/**
+ * Best-effort keyboard layout guess based on a BCP 47 locale string.
+ *
+ * The mapping is intentionally conservative and only covers the most common
+ * layouts. Unknown locales default to `'qwerty'`.
+ *
+ * @param locale - BCP 47 language tag, e.g. `en-US` or `fr-FR`.
+ * @returns Layout hint.
+ */
+export function layoutHintFromLocale(locale: string): LayoutHint {
+  const lang = locale.toLowerCase().split('-')[0]
+  switch (lang) {
+    case 'fr':
+      return 'azerty'
+    case 'de':
+      return 'qwertz'
+    default:
+      return 'qwerty'
+  }
+}
+

--- a/test/input-utils.test.ts
+++ b/test/input-utils.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { applyDeadzone, clamp, layoutHintFromLocale, smoothDamp, type LayoutHint } from '~/engines/input/utils'
+
+describe('clamp', () => {
+  it('restricts value within range', () => {
+    expect(clamp(5, 0, 10)).toBe(5)
+    expect(clamp(-5, 0, 10)).toBe(0)
+    expect(clamp(15, 0, 10)).toBe(10)
+  })
+
+  it('throws when min is greater than max', () => {
+    expect(() => clamp(0, 10, 0)).toThrow(RangeError)
+  })
+})
+
+describe('smoothDamp', () => {
+  it('converges toward the target without overshoot', () => {
+    let value = 0
+    let velocity = 0
+    for (let i = 0; i < 60; i++) {
+      const result = smoothDamp(value, 1, velocity, 0.2, 1 / 60, Infinity)
+      value = result.value
+      velocity = result.velocity
+    }
+    expect(value).toBeCloseTo(1, 2)
+  })
+
+  it('handles zero delta time', () => {
+    const res = smoothDamp(0, 1, 0, 0.3, 0, Infinity)
+    expect(res.value).toBe(0)
+    expect(res.velocity).toBe(0)
+  })
+})
+
+describe('applyDeadzone', () => {
+  it('returns zero inside the deadzone', () => {
+    expect(applyDeadzone(0.05, 0.1)).toBe(0)
+  })
+
+  it('scales values outside the deadzone', () => {
+    expect(applyDeadzone(0.5, 0.2)).toBeCloseTo(0.375)
+    expect(applyDeadzone(-0.5, 0.2)).toBeCloseTo(-0.375)
+  })
+
+  it('rejects invalid deadzone values', () => {
+    expect(() => applyDeadzone(0.5, -0.1)).toThrow(RangeError)
+    expect(() => applyDeadzone(0.5, 1.1)).toThrow(RangeError)
+  })
+})
+
+describe('layoutHintFromLocale', () => {
+  const cases: Array<[string, LayoutHint]> = [
+    ['fr', 'azerty'],
+    ['fr-FR', 'azerty'],
+    ['de-DE', 'qwertz'],
+    ['en-US', 'qwerty'],
+    ['es-ES', 'qwerty'],
+  ]
+
+  for (const [input, expected] of cases) {
+    it(`maps ${input} to ${expected}`, () => {
+      expect(layoutHintFromLocale(input)).toBe(expected)
+    })
+  }
+})
+


### PR DESCRIPTION
## Summary
- add pure input helpers for clamping, smoothing, deadzones, and layout hints
- cover new helpers with unit tests

## Testing
- `npx --yes vitest run` *(fails: Cannot find package 'three'; window is not defined)*
- `npx --yes vitest run test/input-utils.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b83c0806bc832a80a390ac046d7617