### PR TITLE
feat: add keyboard input source

### DIFF
--- a/src/engines/input/InputEngine.ts
+++ b/src/engines/input/InputEngine.ts
@@ -20,7 +20,7 @@ export class InputEngine {
       return
     this.running = true
     for (const source of this.sources)
-      source.start(this.handleInput)
+      source.attach(this.handleInput)
   }
 
   /** Stop all registered input sources. */
@@ -29,7 +29,7 @@ export class InputEngine {
       return
     this.running = false
     for (const source of this.sources)
-      source.stop()
+      source.detach()
   }
 
   /**
@@ -37,6 +37,8 @@ export class InputEngine {
    * Each call produces a new frozen object to avoid shared mutations.
    */
   snapshot(): InputState {
+    for (const source of this.sources)
+      source.poll()
     const actions = Object.freeze({ ...this.actions }) as Readonly<Record<Action, boolean>>
     return Object.freeze({ actions })
   }
@@ -66,7 +68,7 @@ export class InputEngine {
   registerSource(source: InputSource): void {
     this.sources.add(source)
     if (this.running)
-      source.start(this.handleInput)
+      source.attach(this.handleInput)
   }
 
   private readonly handleInput = (action: Action, pressed: boolean): void => {

--- a/src/engines/input/README.md
+++ b/src/engines/input/README.md
@@ -22,9 +22,17 @@ read inputs without risk of mutation.
 ## API
 
 - `start()` / `stop()` — control all registered sources.
-- `snapshot()` — returns the current immutable {@link InputState}.
+- `snapshot()` — polls sources and returns the current immutable {@link InputState}.
 - `onAction(action, cb)` — observe transitions for a specific action.
 - `registerSource(source)` — plug in a new device input translator.
+
+## Input Sources
+
+An `InputSource` exposes three methods:
+
+- `attach(emit)` — begin listening to the underlying device and queue events.
+- `detach()` — remove listeners and clear internal state.
+- `poll()` — flush queued events through the `emit` callback.
 
 Sources are intentionally decoupled from the engine so new devices can be
 supported without modifying existing logic.

--- a/src/engines/input/sources/KeyboardSource.ts
+++ b/src/engines/input/sources/KeyboardSource.ts
@@ -1,0 +1,117 @@
+import { Action, type InputSource } from '../types'
+
+/**
+ * Translates keyboard and mouse events into high level {@link Action} values.
+ *
+ * The source queues events on native input and flushes them when polled. This
+ * keeps input processing aligned with the engine's update loop and avoids
+ * stale state.
+ */
+export class KeyboardSource implements InputSource {
+  private emit: ((action: Action, pressed: boolean) => void) | null = null
+  private target: EventTarget | null = null
+  private readonly queue: Array<{ action: Action; pressed: boolean }> = []
+
+  attach(emit: (action: Action, pressed: boolean) => void, target: EventTarget = window): void {
+    if (this.emit)
+      return
+    this.emit = emit
+    this.target = target
+    target.addEventListener('keydown', this.handleKeyDown)
+    target.addEventListener('keyup', this.handleKeyUp)
+    target.addEventListener('mousedown', this.handleMouseDown)
+    target.addEventListener('mouseup', this.handleMouseUp)
+  }
+
+  detach(): void {
+    if (!this.emit || !this.target)
+      return
+    this.target.removeEventListener('keydown', this.handleKeyDown)
+    this.target.removeEventListener('keyup', this.handleKeyUp)
+    this.target.removeEventListener('mousedown', this.handleMouseDown)
+    this.target.removeEventListener('mouseup', this.handleMouseUp)
+    this.emit = null
+    this.target = null
+    this.queue.length = 0
+  }
+
+  poll(): void {
+    if (!this.emit)
+      return
+    for (const { action, pressed } of this.queue)
+      this.emit(action, pressed)
+    this.queue.length = 0
+  }
+
+  private readonly handleKeyDown = (event: KeyboardEvent): void => {
+    if (event.repeat)
+      return
+    const action = this.mapKey(event.code)
+    if (!action)
+      return
+    event.preventDefault()
+    this.queue.push({ action, pressed: true })
+  }
+
+  private readonly handleKeyUp = (event: KeyboardEvent): void => {
+    const action = this.mapKey(event.code)
+    if (!action)
+      return
+    event.preventDefault()
+    this.queue.push({ action, pressed: false })
+  }
+
+  private readonly handleMouseDown = (event: MouseEvent): void => {
+    const action = this.mapMouseButton(event.button)
+    if (!action)
+      return
+    event.preventDefault()
+    this.queue.push({ action, pressed: true })
+  }
+
+  private readonly handleMouseUp = (event: MouseEvent): void => {
+    const action = this.mapMouseButton(event.button)
+    if (!action)
+      return
+    event.preventDefault()
+    this.queue.push({ action, pressed: false })
+  }
+
+  private mapKey(code: string): Action | null {
+    switch (code) {
+      case 'KeyW':
+        return Action.MoveForward
+      case 'KeyS':
+        return Action.MoveBackward
+      case 'KeyA':
+        return Action.MoveLeft
+      case 'KeyD':
+        return Action.MoveRight
+      case 'Space':
+        return Action.Jump
+      case 'ShiftLeft':
+      case 'ShiftRight':
+        return Action.Sprint
+      case 'ControlLeft':
+      case 'ControlRight':
+        return Action.Crouch
+      case 'KeyE':
+        return Action.Interact
+      case 'Escape':
+        return Action.Pause
+      default:
+        return null
+    }
+  }
+
+  private mapMouseButton(button: number): Action | null {
+    switch (button) {
+      case 0:
+        return Action.Primary
+      case 2:
+        return Action.Secondary
+      default:
+        return null
+    }
+  }
+}

--- a/src/engines/input/types.ts
+++ b/src/engines/input/types.ts
@@ -4,6 +4,9 @@ export enum Action {
   MoveLeft = 'move-left',
   MoveRight = 'move-right',
   Jump = 'jump',
+  Sprint = 'sprint',
+  Crouch = 'crouch',
+  Interact = 'interact',
   Primary = 'primary',
   Secondary = 'secondary',
   Pause = 'pause',
@@ -18,10 +21,15 @@ export interface InputState {
 }
 
 /**
- * An input source translates raw device events into high-level actions.
- * Sources are expected to emit action changes via the provided callback.
+ * An input source translates raw device signals into high-level {@link Action}
+ * values. Sources attach to an event target, translate native events into
+ * actions and expose them through the provided callback when polled.
  */
 export interface InputSource {
-  start(emit: (action: Action, pressed: boolean) => void): void;
-  stop(): void;
+  /** Begin listening to the underlying device. */
+  attach(emit: (action: Action, pressed: boolean) => void): void;
+  /** Stop listening to the device and release any resources. */
+  detach(): void;
+  /** Flush any queued events and emit resulting action changes. */
+  poll(): void;
 }

--- a/test/input-engine.test.ts
+++ b/test/input-engine.test.ts
@@ -5,12 +5,13 @@ import { Action, type InputSource } from '~/engines/input/types'
 describe('InputEngine', () => {
   class MockSource implements InputSource {
     private emit: ((action: Action, pressed: boolean) => void) | null = null
-    start(emit: (action: Action, pressed: boolean) => void): void {
+    attach(emit: (action: Action, pressed: boolean) => void): void {
       this.emit = emit
     }
-    stop(): void {
+    detach(): void {
       this.emit = null
     }
+    poll(): void {}
     trigger(action: Action, pressed: boolean): void {
       this.emit?.(action, pressed)
     }

--- a/test/keyboard-source.test.ts
+++ b/test/keyboard-source.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+import { Action } from '~/engines/input/types'
+import { KeyboardSource } from '~/engines/input/sources/KeyboardSource'
+
+describe('KeyboardSource', () => {
+  it('emits mapped key actions when polled', () => {
+    const emit = vi.fn()
+    const source = new KeyboardSource()
+    source.attach(emit)
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyW' }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: 'KeyW' }))
+    source.poll()
+
+    expect(emit).toHaveBeenNthCalledWith(1, Action.MoveForward, true)
+    expect(emit).toHaveBeenNthCalledWith(2, Action.MoveForward, false)
+
+    source.detach()
+  })
+
+  it('emits mouse button actions', () => {
+    const emit = vi.fn()
+    const source = new KeyboardSource()
+    source.attach(emit)
+
+    window.dispatchEvent(new MouseEvent('mousedown', { button: 0 }))
+    window.dispatchEvent(new MouseEvent('mouseup', { button: 0 }))
+    source.poll()
+
+    expect(emit).toHaveBeenNthCalledWith(1, Action.Primary, true)
+    expect(emit).toHaveBeenNthCalledWith(2, Action.Primary, false)
+
+    source.detach()
+  })
+})


### PR DESCRIPTION
## Summary
- add keyboard and mouse input source with configurable polling
- extend input engine to support attach/detach and snapshot polling
- map common controls including movement, sprint, crouch, interact, and pause

## Testing
- `npx vitest run -c vitest.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b83dbee010832a98577f41e3019014