### PR TITLE
feat(input): add mouse movement source

### DIFF
--- a/src/engines/input/sources/MouseSource.ts
+++ b/src/engines/input/sources/MouseSource.ts
@@ -1,0 +1,90 @@
+/**
+ * Captures relative mouse movement for look controls.
+ *
+ * Movement is reported via the provided callback when {@link poll} is invoked.
+ * Values are accumulated from `mousemove` events and scaled by sensitivity.
+ * Optional Y-axis inversion is supported to match user preference.
+ */
+export interface MouseSourceOptions {
+  /** Scalar applied to movement deltas. */
+  readonly sensitivity?: number
+  /** Inverts the Y axis when true. */
+  readonly invertY?: boolean
+}
+
+export class MouseSource {
+  private emit: ((deltaX: number, deltaY: number) => void) | null = null
+  private target: EventTarget | null = null
+  private readonly sensitivity: number
+  private readonly invertY: boolean
+  private locked = false
+  private lastX: number | null = null
+  private lastY: number | null = null
+  private deltaX = 0
+  private deltaY = 0
+
+  constructor(options: MouseSourceOptions = {}) {
+    this.sensitivity = options.sensitivity ?? 1
+    this.invertY = options.invertY ?? false
+  }
+
+  /** Begin listening to mouse movement. */
+  attach(emit: (deltaX: number, deltaY: number) => void, target: EventTarget = window): void {
+    if (this.emit)
+      return
+    this.emit = emit
+    this.target = target
+    target.addEventListener('mousemove', this.handleMouseMove)
+    document.addEventListener('pointerlockchange', this.handlePointerLockChange)
+    this.locked = document.pointerLockElement !== null
+  }
+
+  /** Stop listening and reset internal state. */
+  detach(): void {
+    if (!this.emit || !this.target)
+      return
+    this.target.removeEventListener('mousemove', this.handleMouseMove)
+    document.removeEventListener('pointerlockchange', this.handlePointerLockChange)
+    this.emit = null
+    this.target = null
+    this.deltaX = 0
+    this.deltaY = 0
+    this.lastX = null
+    this.lastY = null
+    this.locked = false
+  }
+
+  /** Flush accumulated movement through the emit callback. */
+  poll(): void {
+    if (!this.emit)
+      return
+    if (this.deltaX === 0 && this.deltaY === 0)
+      return
+    const factor = this.invertY ? -1 : 1
+    const dx = this.deltaX * this.sensitivity
+    const dy = this.deltaY * this.sensitivity * factor
+    this.emit(dx, dy)
+    this.deltaX = 0
+    this.deltaY = 0
+  }
+
+  private readonly handlePointerLockChange = (): void => {
+    this.locked = document.pointerLockElement !== null
+    this.lastX = null
+    this.lastY = null
+  }
+
+  private readonly handleMouseMove = (event: MouseEvent): void => {
+    if (this.locked) {
+      this.deltaX += event.movementX
+      this.deltaY += event.movementY
+      return
+    }
+    if (this.lastX !== null && this.lastY !== null) {
+      this.deltaX += event.clientX - this.lastX
+      this.deltaY += event.clientY - this.lastY
+    }
+    this.lastX = event.clientX
+    this.lastY = event.clientY
+  }
+}

--- a/test/mouse-source.test.ts
+++ b/test/mouse-source.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+import { MouseSource } from '~/engines/input/sources/MouseSource'
+
+describe('mouse source', () => {
+  const setPointerLock = (locked: boolean): void => {
+    (document as any).pointerLockElement = locked ? document.body : null
+    document.dispatchEvent(new Event('pointerlockchange'))
+  }
+
+  it('emits scaled movement when pointer is locked', () => {
+    const emit = vi.fn()
+    const source = new MouseSource({ sensitivity: 0.5 })
+    source.attach(emit)
+
+    setPointerLock(true)
+    const event = new MouseEvent('mousemove')
+    Object.defineProperty(event, 'movementX', { value: 10 })
+    Object.defineProperty(event, 'movementY', { value: -20 })
+    window.dispatchEvent(event)
+
+    source.poll()
+
+    expect(emit).toHaveBeenCalledWith(5, -10)
+    source.detach()
+  })
+
+  it('inverts Y axis when configured', () => {
+    const emit = vi.fn()
+    const source = new MouseSource({ invertY: true })
+    source.attach(emit)
+
+    setPointerLock(true)
+    const event = new MouseEvent('mousemove')
+    Object.defineProperty(event, 'movementX', { value: 0 })
+    Object.defineProperty(event, 'movementY', { value: 8 })
+    window.dispatchEvent(event)
+
+    source.poll()
+
+    expect(emit).toHaveBeenCalledWith(0, -8)
+    source.detach()
+  })
+
+  it('falls back to client deltas when pointer not locked', () => {
+    const emit = vi.fn()
+    const source = new MouseSource()
+    source.attach(emit)
+
+    setPointerLock(false)
+    window.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 100 }))
+    window.dispatchEvent(new MouseEvent('mousemove', { clientX: 90, clientY: 130 }))
+
+    source.poll()
+
+    expect(emit).toHaveBeenCalledWith(-10, 30)
+    source.detach()
+  })
+})


### PR DESCRIPTION
## Summary
- add MouseSource capturing pointer movement with sensitivity and optional Y-axis inversion
- provide unit tests for MouseSource

## Testing
- `npx eslint src/engines/input/sources/MouseSource.ts test/mouse-source.test.ts`
- `npx vitest test/mouse-source.test.ts` *(fails: Failed to fetch web fonts: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68b83fb0b4d0832a871c36324a23754d