### PR TITLE
feat: add gamepad input source

### DIFF
--- a/src/engines/input/sources/GamepadSource.ts
+++ b/src/engines/input/sources/GamepadSource.ts
@@ -1,0 +1,172 @@
+import { Action, type InputSource } from '../types'
+import { applyDeadzone, clamp } from '../utils'
+
+/** Options to configure a {@link GamepadSource}. */
+export interface GamepadSourceOptions {
+  /** Index of the gamepad to monitor. Defaults to the first gamepad (0). */
+  readonly index?: number
+  /** Deadzone applied to stick axes. Defaults to `0.1`. */
+  readonly deadzone?: number
+  /** Callback receiving look deltas from the right stick. */
+  readonly onLook?: (deltaX: number, deltaY: number) => void
+}
+
+/** Options for triggering gamepad vibration. */
+export interface RumbleOptions {
+  /** Duration of the effect in milliseconds. Defaults to `100`. */
+  readonly duration?: number
+  /** Strength of the low-frequency motor in the range `[0,1]`. Defaults to `1`. */
+  readonly strongMagnitude?: number
+  /** Strength of the high-frequency motor in the range `[0,1]`. Defaults to `1`. */
+  readonly weakMagnitude?: number
+}
+
+/**
+ * Translates Gamepad API signals into high-level {@link Action} values.
+ *
+ * - **Left stick** → movement actions
+ * - **Right stick** → look deltas via `onLook`
+ * - **Buttons** → mapped actions (A→Jump, B→Crouch, etc.)
+ *
+ * The source listens for connect/disconnect events and automatically resets
+ * state to avoid stuck inputs. Analogue stick values are normalised to `[-1,1]`
+ * and pass through a configurable deadzone.
+ */
+export class GamepadSource implements InputSource {
+  private emit: ((action: Action, pressed: boolean) => void) | null = null
+  private target: EventTarget | null = null
+  private readonly index: number
+  private readonly deadzone: number
+  private readonly onLook?: (dx: number, dy: number) => void
+  private readonly state: Record<Action, boolean> = {
+    [Action.MoveForward]: false,
+    [Action.MoveBackward]: false,
+    [Action.MoveLeft]: false,
+    [Action.MoveRight]: false,
+    [Action.Jump]: false,
+    [Action.Sprint]: false,
+    [Action.Crouch]: false,
+    [Action.Interact]: false,
+    [Action.Primary]: false,
+    [Action.Secondary]: false,
+    [Action.Pause]: false,
+  }
+  private connected = false
+
+  constructor(options: GamepadSourceOptions = {}) {
+    this.index = options.index ?? 0
+    this.deadzone = options.deadzone ?? 0.1
+    this.onLook = options.onLook
+  }
+
+  /** Begin listening to gamepad events. */
+  attach(emit: (action: Action, pressed: boolean) => void, target: EventTarget = window): void {
+    if (this.emit)
+      return
+    this.emit = emit
+    this.target = target
+    target.addEventListener('gamepadconnected', this.handleConnect)
+    target.addEventListener('gamepaddisconnected', this.handleDisconnect)
+    this.scanGamepads()
+  }
+
+  /** Stop listening and reset internal state. */
+  detach(): void {
+    if (!this.emit || !this.target)
+      return
+    this.target.removeEventListener('gamepadconnected', this.handleConnect)
+    this.target.removeEventListener('gamepaddisconnected', this.handleDisconnect)
+    this.emit = null
+    this.target = null
+    this.connected = false
+    this.releaseAll()
+  }
+
+  /** Flush current gamepad state through the emit callback. */
+  poll(): void {
+    if (!this.emit || !this.connected)
+      return
+    const pad = navigator.getGamepads()[this.index]
+    if (!pad)
+      return
+
+    // Left stick controls movement
+    const lx = applyDeadzone(clamp(pad.axes[0] ?? 0, -1, 1), this.deadzone)
+    const ly = applyDeadzone(clamp(pad.axes[1] ?? 0, -1, 1), this.deadzone)
+    this.updateAction(Action.MoveLeft, lx < 0)
+    this.updateAction(Action.MoveRight, lx > 0)
+    this.updateAction(Action.MoveForward, ly < 0)
+    this.updateAction(Action.MoveBackward, ly > 0)
+
+    // Right stick controls look
+    if (this.onLook) {
+      const rx = applyDeadzone(clamp(pad.axes[2] ?? 0, -1, 1), this.deadzone)
+      const ry = applyDeadzone(clamp(pad.axes[3] ?? 0, -1, 1), this.deadzone)
+      if (rx !== 0 || ry !== 0)
+        this.onLook(rx, ry)
+    }
+
+    // Button mappings
+    this.processButton(pad.buttons[0], Action.Jump) // A
+    this.processButton(pad.buttons[1], Action.Crouch) // B
+    this.processButton(pad.buttons[2], Action.Interact) // X
+    this.processButton(pad.buttons[4], Action.Primary) // LB
+    this.processButton(pad.buttons[5], Action.Secondary) // RB
+    this.processButton(pad.buttons[9], Action.Pause) // Start
+    this.processButton(pad.buttons[10], Action.Sprint) // Left stick click
+  }
+
+  /**
+   * Trigger a vibration effect if the gamepad supports it. Silent when
+   * unavailable.
+   */
+  async rumble(options: RumbleOptions = {}): Promise<void> {
+    const pad = navigator.getGamepads()[this.index]
+    const actuator = pad?.vibrationActuator
+    if (!actuator)
+      return
+    await actuator.playEffect('dual-rumble', {
+      startDelay: 0,
+      duration: options.duration ?? 100,
+      strongMagnitude: options.strongMagnitude ?? 1,
+      weakMagnitude: options.weakMagnitude ?? 1,
+    })
+  }
+
+  private readonly handleConnect = (event: Event): void => {
+    const gp = (event as any).gamepad as Gamepad | undefined
+    if (gp && gp.index === this.index)
+      this.connected = true
+  }
+
+  private readonly handleDisconnect = (event: Event): void => {
+    const gp = (event as any).gamepad as Gamepad | undefined
+    if (gp && gp.index === this.index) {
+      this.connected = false
+      this.releaseAll()
+    }
+  }
+
+  private processButton(button: GamepadButton | undefined, action: Action): void {
+    const pressed = button?.pressed ?? false
+    this.updateAction(action, pressed)
+  }
+
+  private updateAction(action: Action, pressed: boolean): void {
+    if (this.state[action] === pressed)
+      return
+    this.state[action] = pressed
+    this.emit?.(action, pressed)
+  }
+
+  private releaseAll(): void {
+    for (const action of Object.keys(this.state) as Action[])
+      this.updateAction(action, false)
+  }
+
+  private scanGamepads(): void {
+    const pad = navigator.getGamepads()[this.index]
+    this.connected = pad !== undefined && pad !== null
+  }
+}
+

--- a/test/gamepad-source.test.ts
+++ b/test/gamepad-source.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest'
+import { GamepadSource } from '~/engines/input/sources/GamepadSource'
+import { Action } from '~/engines/input/types'
+
+function createGamepad(): Gamepad {
+  const buttons = Array.from({ length: 17 }, () => ({ pressed: false, value: 0, touched: false }))
+  const gp: Gamepad = {
+    axes: [0, 0, 0, 0],
+    buttons: buttons as any,
+    connected: true,
+    id: 'stub',
+    index: 0,
+    mapping: 'standard',
+    timestamp: 0,
+  }
+  return gp
+}
+
+describe('GamepadSource', () => {
+  it('emits actions and look data', () => {
+    const pad = createGamepad()
+    pad.axes[1] = -1 // forward
+    pad.axes[2] = 0.5
+    pad.axes[3] = -0.25
+    pad.buttons[0] = { pressed: true, value: 1, touched: true }
+
+    const emit = vi.fn()
+    const look = vi.fn()
+    const source = new GamepadSource({ onLook: look })
+
+    ;(navigator as any).getGamepads = () => [pad]
+
+    source.attach(emit)
+    window.dispatchEvent(new Event('gamepadconnected', { bubbles: true }))
+
+    source.poll()
+
+    expect(emit).toHaveBeenCalledWith(Action.MoveForward, true)
+    expect(emit).toHaveBeenCalledWith(Action.Jump, true)
+    expect(look).toHaveBeenCalledWith(0.5, -0.25)
+  })
+
+  it('releases actions on disconnect', () => {
+    const pad = createGamepad()
+    pad.buttons[0] = { pressed: true, value: 1, touched: true }
+
+    const emit = vi.fn()
+    const source = new GamepadSource()
+    ;(navigator as any).getGamepads = () => [pad]
+
+    source.attach(emit)
+    const connect = new Event('gamepadconnected') as any
+    connect.gamepad = pad
+    window.dispatchEvent(connect)
+
+    source.poll()
+    expect(emit).toHaveBeenCalledWith(Action.Jump, true)
+
+    const disconnect = new Event('gamepaddisconnected') as any
+    disconnect.gamepad = pad
+    window.dispatchEvent(disconnect)
+
+    expect(emit).toHaveBeenCalledWith(Action.Jump, false)
+  })
+
+  it('plays rumble effect when supported', async () => {
+    const pad = createGamepad()
+    const playEffect = vi.fn().mockResolvedValue(undefined)
+    ;(pad as any).vibrationActuator = { type: 'dual-rumble', playEffect }
+    ;(navigator as any).getGamepads = () => [pad]
+
+    const source = new GamepadSource()
+    source.attach(vi.fn())
+    const connect = new Event('gamepadconnected') as any
+    connect.gamepad = pad
+    window.dispatchEvent(connect)
+
+    await source.rumble({ duration: 200 })
+    expect(playEffect).toHaveBeenCalled()
+  })
+})
+


### PR DESCRIPTION
## Summary
- add GamepadSource to translate Gamepad API signals into engine actions
- support look deltas, deadzone, connect/disconnect handling and optional rumble
- cover behaviour with unit tests

## Testing
- `npx --yes vitest run test/gamepad-source.test.ts test/input-engine.test.ts test/input-utils.test.ts` *(fails: Cannot find package '@intlify/unplugin-vue-i18n' imported from vite.config.ts)*


------
https://chatgpt.com/codex/tasks/task_e_68b854ba5158832a9a9bb3b9df68e38e