### PR TITLE
feat: add touch input components

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -12,5 +12,7 @@ declare module 'vue' {
     RouterView: typeof import('vue-router')['RouterView']
     ThreeCanvas: typeof import('./components/three-canvas/index.vue')['default']
     Ui: typeof import('./components/Ui.vue')['default']
+    UiInputActionButtons: typeof import('./components/ui/input/ActionButtons.vue')['default']
+    UiInputVirtualStick: typeof import('./components/ui/input/VirtualStick.vue')['default']
   }
 }

--- a/src/components/ui/input/ActionButtons.vue
+++ b/src/components/ui/input/ActionButtons.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+/**
+ * Mobile action buttons for jump, interact, crouch and sprint.
+ *
+ * Each button emits its respective event with a boolean indicating whether the
+ * button is pressed (`true`) or released (`false`).
+ */
+const emit = defineEmits<{
+  (e: 'jump', pressed: boolean): void
+  (e: 'interact', pressed: boolean): void
+  (e: 'crouch', pressed: boolean): void
+  (e: 'sprint', pressed: boolean): void
+}>()
+
+function press(action: 'jump' | 'interact' | 'crouch' | 'sprint', pressed: boolean): void {
+  emit(action, pressed)
+}
+</script>
+
+<template>
+  <div class="action-buttons">
+    <button
+      class="action-button"
+      @touchstart.prevent="press('jump', true)"
+      @touchend.prevent="press('jump', false)"
+      @touchcancel.prevent="press('jump', false)"
+    >
+      Jump
+    </button>
+    <button
+      class="action-button"
+      @touchstart.prevent="press('interact', true)"
+      @touchend.prevent="press('interact', false)"
+      @touchcancel.prevent="press('interact', false)"
+    >
+      Interact
+    </button>
+    <button
+      class="action-button"
+      @touchstart.prevent="press('crouch', true)"
+      @touchend.prevent="press('crouch', false)"
+      @touchcancel.prevent="press('crouch', false)"
+    >
+      Crouch
+    </button>
+    <button
+      class="action-button"
+      @touchstart.prevent="press('sprint', true)"
+      @touchend.prevent="press('sprint', false)"
+      @touchcancel.prevent="press('sprint', false)"
+    >
+      Sprint
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.action-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  touch-action: none;
+}
+
+.action-button {
+  width: 80px;
+  height: 40px;
+  border-radius: 0.25rem;
+  background: rgba(255, 255, 255, 0.1);
+  color: white;
+}
+</style>

--- a/src/components/ui/input/VirtualStick.vue
+++ b/src/components/ui/input/VirtualStick.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+/**
+ * Virtual thumb stick providing analog movement on touch devices.
+ *
+ * The component emits normalized `x` and `y` values in the range `[-1, 1]`
+ * whenever the stick is dragged. Values are reset to zero when the touch
+ * ends.
+ */
+const emit = defineEmits<{
+  (e: 'move', x: number, y: number): void
+}>()
+
+const radius = 50
+const position = ref({ x: 0, y: 0 })
+let startX = 0
+let startY = 0
+let active = false
+
+function handleStart(event: TouchEvent): void {
+  const touch = event.touches[0]
+  startX = touch.clientX
+  startY = touch.clientY
+  active = true
+  event.preventDefault()
+}
+
+function handleMove(event: TouchEvent): void {
+  if (!active)
+    return
+  const touch = event.touches[0]
+  const dx = touch.clientX - startX
+  const dy = touch.clientY - startY
+  const distance = Math.min(Math.hypot(dx, dy), radius)
+  const angle = Math.atan2(dy, dx)
+  const x = Math.cos(angle) * distance
+  const y = Math.sin(angle) * distance
+  position.value = { x, y }
+  emit('move', x / radius, y / radius)
+  event.preventDefault()
+}
+
+function handleEnd(): void {
+  if (!active)
+    return
+  active = false
+  position.value = { x: 0, y: 0 }
+  emit('move', 0, 0)
+}
+
+const thumbStyle = computed(() => ({
+  transform: `translate(calc(-50% + ${position.value.x}px), calc(-50% + ${position.value.y}px))`,
+}))
+</script>
+
+<template>
+  <div
+    class="virtual-stick"
+    @touchstart.prevent="handleStart"
+    @touchmove.prevent="handleMove"
+    @touchend.prevent="handleEnd"
+    @touchcancel.prevent="handleEnd"
+  >
+    <div class="thumb" :style="thumbStyle" />
+  </div>
+</template>
+
+<style scoped>
+.virtual-stick {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.05);
+  touch-action: none;
+}
+
+.thumb {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 40px;
+  height: 40px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.3);
+  transform: translate(-50%, -50%);
+  transition: transform 0.05s linear;
+}
+</style>

--- a/src/engines/input/sources/TouchSource.ts
+++ b/src/engines/input/sources/TouchSource.ts
@@ -1,0 +1,108 @@
+/**
+ * Captures swipe gestures for camera look on touch devices.
+ *
+ * Movement is accumulated from `touchmove` events and emitted when {@link poll}
+ * is called. Small jitter is ignored using a configurable threshold to avoid
+ * unintended camera shake. Default scrolling behaviour is prevented while the
+ * source is active.
+ */
+export interface TouchSourceOptions {
+  /** Multiplier applied to movement deltas. */
+  readonly sensitivity?: number
+  /** Invert the Y axis when true. */
+  readonly invertY?: boolean
+  /** Minimum delta (in pixels) required before movement is registered. */
+  readonly jitterThreshold?: number
+}
+
+export class TouchSource {
+  private emit: ((deltaX: number, deltaY: number) => void) | null = null
+  private target: EventTarget | null = null
+  private readonly sensitivity: number
+  private readonly invertY: boolean
+  private readonly jitter: number
+  private deltaX = 0
+  private deltaY = 0
+  private lastX: number | null = null
+  private lastY: number | null = null
+
+  constructor(options: TouchSourceOptions = {}) {
+    this.sensitivity = options.sensitivity ?? 1
+    this.invertY = options.invertY ?? false
+    this.jitter = options.jitterThreshold ?? 4
+  }
+
+  /** Start listening for touch input. */
+  attach(emit: (deltaX: number, deltaY: number) => void, target: EventTarget = window): void {
+    if (this.emit)
+      return
+    this.emit = emit
+    this.target = target
+    target.addEventListener('touchstart', this.handleTouchStart, { passive: false })
+    target.addEventListener('touchmove', this.handleTouchMove, { passive: false })
+    target.addEventListener('touchend', this.handleTouchEnd, { passive: false })
+    target.addEventListener('touchcancel', this.handleTouchEnd, { passive: false })
+  }
+
+  /** Stop listening and reset all internal state. */
+  detach(): void {
+    if (!this.emit || !this.target)
+      return
+    this.target.removeEventListener('touchstart', this.handleTouchStart)
+    this.target.removeEventListener('touchmove', this.handleTouchMove)
+    this.target.removeEventListener('touchend', this.handleTouchEnd)
+    this.target.removeEventListener('touchcancel', this.handleTouchEnd)
+    this.emit = null
+    this.target = null
+    this.deltaX = 0
+    this.deltaY = 0
+    this.lastX = null
+    this.lastY = null
+  }
+
+  /** Flush accumulated movement through the emit callback. */
+  poll(): void {
+    if (!this.emit)
+      return
+    if (this.deltaX === 0 && this.deltaY === 0)
+      return
+    const factor = this.invertY ? -1 : 1
+    const dx = this.deltaX * this.sensitivity
+    const dy = this.deltaY * this.sensitivity * factor
+    this.emit(dx, dy)
+    this.deltaX = 0
+    this.deltaY = 0
+  }
+
+  private readonly handleTouchStart = (event: TouchEvent): void => {
+    if (event.touches.length === 0)
+      return
+    const touch = event.touches[0]
+    this.lastX = touch.clientX
+    this.lastY = touch.clientY
+  }
+
+  private readonly handleTouchMove = (event: TouchEvent): void => {
+    if (event.touches.length === 0)
+      return
+    const touch = event.touches[0]
+    const x = touch.clientX
+    const y = touch.clientY
+    if (this.lastX !== null && this.lastY !== null) {
+      const dx = x - this.lastX
+      const dy = y - this.lastY
+      if (Math.abs(dx) > this.jitter)
+        this.deltaX += dx
+      if (Math.abs(dy) > this.jitter)
+        this.deltaY += dy
+    }
+    this.lastX = x
+    this.lastY = y
+    event.preventDefault()
+  }
+
+  private readonly handleTouchEnd = (): void => {
+    this.lastX = null
+    this.lastY = null
+  }
+}

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -2,10 +2,15 @@
 import DebugOverlay from '~/dev/DebugOverlay.vue'
 
 const showDebug = import.meta.env.DEV
+const hasTouch = typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0
 </script>
 
 <template>
   <ThreeCanvas background="#0e0e12" :show-helpers="true">
-    <DebugOverlay v-if="showDebug" />
+    <Ui>
+      <DebugOverlay v-if="showDebug" />
+      <UiInputVirtualStick v-if="hasTouch" class="absolute left-4 bottom-4" />
+      <UiInputActionButtons v-if="hasTouch" class="absolute right-4 bottom-4" />
+    </Ui>
   </ThreeCanvas>
 </template>

--- a/test/touch-source.test.ts
+++ b/test/touch-source.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { TouchSource } from '~/engines/input/sources/TouchSource'
+
+describe('touch source', () => {
+  const createEvent = (type: string, x: number, y: number): TouchEvent => {
+    const event = new Event(type, { cancelable: true }) as TouchEvent
+    Object.defineProperty(event, 'touches', { value: [{ clientX: x, clientY: y }] })
+    return event
+  }
+
+  it('emits scaled movement and prevents default scrolling', () => {
+    const emit = vi.fn()
+    const source = new TouchSource({ sensitivity: 0.5, jitterThreshold: 0 })
+    source.attach(emit)
+
+    window.dispatchEvent(createEvent('touchstart', 0, 0))
+    const move = createEvent('touchmove', 10, -20)
+    window.dispatchEvent(move)
+
+    source.poll()
+
+    expect(emit).toHaveBeenCalledWith(5, -10)
+    expect(move.defaultPrevented).toBe(true)
+    source.detach()
+  })
+
+  it('ignores movement below jitter threshold', () => {
+    const emit = vi.fn()
+    const source = new TouchSource({ jitterThreshold: 5 })
+    source.attach(emit)
+
+    window.dispatchEvent(createEvent('touchstart', 0, 0))
+    window.dispatchEvent(createEvent('touchmove', 3, 4)) // below threshold on both axes
+
+    source.poll()
+
+    expect(emit).not.toHaveBeenCalled()
+    source.detach()
+  })
+})


### PR DESCRIPTION
## Summary
- add `TouchSource` to translate touch swipes into look deltas with jitter filtering and scroll prevention
- create mobile UI components `UiInputVirtualStick` and `UiInputActionButtons`
- auto-detect touch support and render new controls on touch devices

## Testing
- `npx vitest` *(fails: GamepadSource > emits actions and look data)*

------
https://chatgpt.com/codex/tasks/task_e_68b856a95ea8832a8e26b88d4094da06