### PR TITLE
feat: add FPS camera and character controller components

### DIFF
--- a/src/ecs/components/CharacterController.ts
+++ b/src/ecs/components/CharacterController.ts
@@ -1,0 +1,35 @@
+/**
+ * Movement configuration for a character-controlled entity.
+ */
+export interface CharacterControllerOptions {
+  /** Base walking speed in units per second. */
+  movementSpeed?: number
+  /** Multiplier applied to {@link movementSpeed} when sprinting. */
+  sprintMultiplier?: number
+  /** Upward impulse applied when jumping. */
+  jumpImpulse?: number
+}
+
+export class CharacterController {
+  /** Base walking speed in units per second. */
+  movementSpeed: number
+  /** Multiplier applied to {@link movementSpeed} when sprinting. */
+  sprintMultiplier: number
+  /** Upward impulse applied when jumping. */
+  jumpImpulse: number
+  /** Whether the character is currently crouching. */
+  isCrouching = false
+  /** Whether the character is touching the ground. */
+  isGrounded = false
+
+  constructor(options: CharacterControllerOptions = {}) {
+    const {
+      movementSpeed = 5,
+      sprintMultiplier = 1.5,
+      jumpImpulse = 5,
+    } = options
+    this.movementSpeed = movementSpeed
+    this.sprintMultiplier = sprintMultiplier
+    this.jumpImpulse = jumpImpulse
+  }
+}

--- a/src/ecs/components/FpsCamera.ts
+++ b/src/ecs/components/FpsCamera.ts
@@ -1,0 +1,50 @@
+/**
+ * Orientation data for a first-person camera.
+ *
+ * Stores yaw and pitch angles in radians. Pitch is clamped between
+ * configurable limits to prevent unnatural rotations.
+ */
+export interface FpsCameraOptions {
+  /** Initial yaw angle in radians. */
+  yaw?: number
+  /** Initial pitch angle in radians. */
+  pitch?: number
+  /** Lowest allowed pitch angle in radians. Defaults to -\u03c0/2. */
+  minPitch?: number
+  /** Highest allowed pitch angle in radians. Defaults to \u03c0/2. */
+  maxPitch?: number
+}
+
+export class FpsCamera {
+  /** Yaw rotation around the vertical axis, in radians. */
+  yaw: number
+  private _pitch: number
+  readonly minPitch: number
+  readonly maxPitch: number
+
+  constructor(options: FpsCameraOptions = {}) {
+    const {
+      yaw = 0,
+      pitch = 0,
+      minPitch = -Math.PI / 2,
+      maxPitch = Math.PI / 2,
+    } = options
+    this.yaw = yaw
+    this.minPitch = minPitch
+    this.maxPitch = maxPitch
+    this._pitch = 0
+    this.pitch = pitch
+  }
+
+  /**
+   * Pitch rotation around the horizontal axis, in radians.
+   * Values are clamped between {@link minPitch} and {@link maxPitch}.
+   */
+  get pitch(): number {
+    return this._pitch
+  }
+
+  set pitch(value: number) {
+    this._pitch = Math.min(this.maxPitch, Math.max(this.minPitch, value))
+  }
+}

--- a/test/character-controller.test.ts
+++ b/test/character-controller.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { CharacterController } from '~/ecs/components/CharacterController'
+
+describe('character controller', () => {
+  it('initializes with default values', () => {
+    const controller = new CharacterController()
+    expect(controller.movementSpeed).toBe(5)
+    expect(controller.sprintMultiplier).toBe(1.5)
+    expect(controller.jumpImpulse).toBe(5)
+    expect(controller.isCrouching).toBe(false)
+    expect(controller.isGrounded).toBe(false)
+  })
+
+  it('accepts custom configuration', () => {
+    const controller = new CharacterController({ movementSpeed: 3, sprintMultiplier: 2, jumpImpulse: 8 })
+    expect(controller.movementSpeed).toBe(3)
+    expect(controller.sprintMultiplier).toBe(2)
+    expect(controller.jumpImpulse).toBe(8)
+  })
+})

--- a/test/fps-camera.test.ts
+++ b/test/fps-camera.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { FpsCamera } from '~/ecs/components/FpsCamera'
+
+describe('fps camera', () => {
+  it('clamps pitch within provided limits', () => {
+    const camera = new FpsCamera({ minPitch: -1, maxPitch: 1 })
+    camera.pitch = 2
+    expect(camera.pitch).toBe(1)
+    camera.pitch = -2
+    expect(camera.pitch).toBe(-1)
+  })
+})


### PR DESCRIPTION
## Summary
- add `FpsCamera` component with yaw, pitch, and configurable pitch limits
- add `CharacterController` component for movement, sprinting, jumping, and crouch state
- cover new components with unit tests

## Testing
- `npx eslint src/ecs/components/FpsCamera.ts src/ecs/components/CharacterController.ts test/fps-camera.test.ts test/character-controller.test.ts`
- `bun test test/fps-camera.test.ts test/character-controller.test.ts`
- `bun test` *(fails: TypeError: vi.mock is not a function; ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b85b346978832a89a91ae0c9da296f