### PR TITLE
feat: add pointer lock composable and integrate with ThreeCanvas

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -226,7 +226,7 @@ declare global {
   const usePerformanceObserver: typeof import('@vueuse/core')['usePerformanceObserver']
   const usePermission: typeof import('@vueuse/core')['usePermission']
   const usePointer: typeof import('@vueuse/core')['usePointer']
-  const usePointerLock: typeof import('@vueuse/core')['usePointerLock']
+  const usePointerLock: typeof import('./composables/usePointerLock')['usePointerLock']
   const usePointerSwipe: typeof import('@vueuse/core')['usePointerSwipe']
   const usePreferredColorScheme: typeof import('@vueuse/core')['usePreferredColorScheme']
   const usePreferredContrast: typeof import('@vueuse/core')['usePreferredContrast']
@@ -543,7 +543,7 @@ declare module 'vue' {
     readonly usePerformanceObserver: UnwrapRef<typeof import('@vueuse/core')['usePerformanceObserver']>
     readonly usePermission: UnwrapRef<typeof import('@vueuse/core')['usePermission']>
     readonly usePointer: UnwrapRef<typeof import('@vueuse/core')['usePointer']>
-    readonly usePointerLock: UnwrapRef<typeof import('@vueuse/core')['usePointerLock']>
+    readonly usePointerLock: UnwrapRef<typeof import('./composables/usePointerLock')['usePointerLock']>
     readonly usePointerSwipe: UnwrapRef<typeof import('@vueuse/core')['usePointerSwipe']>
     readonly usePreferredColorScheme: UnwrapRef<typeof import('@vueuse/core')['usePreferredColorScheme']>
     readonly usePreferredContrast: UnwrapRef<typeof import('@vueuse/core')['usePreferredContrast']>

--- a/src/components/three-canvas/index.vue
+++ b/src/components/three-canvas/index.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
   showHelpers?: boolean
 }>()
 const canvasEl = ref<HTMLCanvasElement | null>(null)
+const { isLocked, requestLock, exitLock } = usePointerLock(canvasEl)
 let engine: GameEngine | undefined
 // Flag indicating when the Three.js engine is ready so child content can render.
 const isReady = ref<boolean>(false)
@@ -30,11 +31,16 @@ onMounted(() => {
 onBeforeUnmount(() => {
   engine?.dispose()
 })
+
+useEventListener(window, 'keydown', (e: KeyboardEvent) => {
+  if (e.key === 'Escape' && isLocked.value)
+    exitLock()
+})
 </script>
 
 <template>
   <div class="three-canvas-container">
-    <canvas ref="canvasEl" class="three-canvas" />
+    <canvas ref="canvasEl" class="three-canvas" @click="requestLock" />
     <slot v-if="isReady" />
   </div>
 </template>

--- a/src/composables/usePointerLock.ts
+++ b/src/composables/usePointerLock.ts
@@ -1,0 +1,41 @@
+import type { Ref } from 'vue'
+
+/**
+ * Manages Pointer Lock API state for a given element.
+ *
+ * @param target - Target element or ref of the element to lock the pointer on.
+ * @returns Reactive lock state and helpers to request or exit pointer lock.
+ */
+export function usePointerLock(target?: Ref<HTMLElement | null> | HTMLElement | null) {
+  const element = isRef(target) ? target : ref(target ?? null)
+  const isLocked = ref(false)
+
+  /** Request pointer lock on the target element. */
+  function requestLock(): void {
+    element.value?.requestPointerLock()
+  }
+
+  /** Exit pointer lock if currently locked. */
+  function exitLock(): void {
+    if (document.pointerLockElement)
+      document.exitPointerLock()
+  }
+
+  function handleChange(): void {
+    isLocked.value = document.pointerLockElement === element.value
+  }
+
+  useEventListener(document, 'pointerlockchange', handleChange)
+
+  onBeforeUnmount(() => {
+    if (isLocked.value)
+      exitLock()
+  })
+
+  return {
+    isLocked: readonly(isLocked),
+    requestLock,
+    exitLock,
+  }
+}
+

--- a/test/pointer-lock.test.ts
+++ b/test/pointer-lock.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest'
+
+describe('usePointerLock', () => {
+  it('handles request and exit and tracks lock state', () => {
+    const element = Object.assign(document.createElement('div'), {
+      requestPointerLock: vi.fn(),
+    }) as HTMLElement & { requestPointerLock: ReturnType<typeof vi.fn> }
+
+    const exitStub = vi.fn()
+    // @ts-expect-error allow assigning stub
+    document.exitPointerLock = exitStub
+
+    const { isLocked, requestLock, exitLock } = usePointerLock(element)
+
+    requestLock()
+    expect(element.requestPointerLock).toHaveBeenCalled()
+
+    // Simulate entering pointer lock
+    // @ts-expect-error allow setting readonly field
+    document.pointerLockElement = element
+    document.dispatchEvent(new Event('pointerlockchange'))
+    expect(isLocked.value).toBe(true)
+
+    exitLock()
+    expect(exitStub).toHaveBeenCalled()
+
+    // Simulate exiting pointer lock
+    // @ts-expect-error allow setting readonly field
+    document.pointerLockElement = null
+    document.dispatchEvent(new Event('pointerlockchange'))
+    expect(isLocked.value).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add `usePointerLock` composable to manage pointer lock state
- request pointer lock on canvas click and release on escape
- cover pointer lock utilities with unit tests

## Testing
- `npx --yes vitest run` *(fails: Cannot find package '@intlify/unplugin-vue-i18n')*


------
https://chatgpt.com/codex/tasks/task_e_68b85f1d65d4832a8700692b65079c41