### PR TITLE
feat(ui): add hud crosshair and input hints

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -12,6 +12,8 @@ declare module 'vue' {
     RouterView: typeof import('vue-router')['RouterView']
     ThreeCanvas: typeof import('./components/three-canvas/index.vue')['default']
     Ui: typeof import('./components/Ui.vue')['default']
+    UiHudCrosshair: typeof import('./components/ui/hud/Crosshair.vue')['default']
+    UiHudInputHints: typeof import('./components/ui/hud/InputHints.vue')['default']
     UiInputActionButtons: typeof import('./components/ui/input/ActionButtons.vue')['default']
     UiInputVirtualStick: typeof import('./components/ui/input/VirtualStick.vue')['default']
   }

--- a/src/components/ui/hud/Crosshair.vue
+++ b/src/components/ui/hud/Crosshair.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+/**
+ * Centered minimal crosshair reticle for the heads-up display.
+ *
+ * Purely visual; emits no events and captures no input.
+ */
+</script>
+
+<template>
+  <div class="crosshair">
+    <div class="line horizontal" />
+    <div class="line vertical" />
+  </div>
+</template>
+
+<style scoped>
+.crosshair {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+.line {
+  position: absolute;
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.horizontal {
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 1px;
+  transform: translateY(-50%);
+}
+
+.vertical {
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  transform: translateX(-50%);
+}
+</style>
+

--- a/src/components/ui/hud/InputHints.vue
+++ b/src/components/ui/hud/InputHints.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { layoutHintFromLocale } from '~/engines/input/utils'
+
+/**
+ * Displays movement control hints based on the active input device.
+ *
+ * Keyboard hints adapt to the user's locale, showing either WASD or ZQSD.
+ * When a gamepad is connected, a left-stick icon replaces the keys.
+ */
+const { locale } = useI18n()
+
+const activeDevice = ref<'keyboard' | 'gamepad'>('keyboard')
+
+function handleKeyboard(): void {
+  activeDevice.value = 'keyboard'
+}
+
+function handleGamepad(): void {
+  activeDevice.value = 'gamepad'
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', handleKeyboard, { passive: true })
+  window.addEventListener('gamepadconnected', handleGamepad)
+  window.addEventListener('gamepaddisconnected', handleKeyboard)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeyboard)
+  window.removeEventListener('gamepadconnected', handleGamepad)
+  window.removeEventListener('gamepaddisconnected', handleKeyboard)
+})
+
+const keys = computed(() => {
+  if (activeDevice.value !== 'keyboard')
+    return []
+  const hint = layoutHintFromLocale(locale.value)
+  return hint === 'azerty' ? ['Z', 'Q', 'S', 'D'] : ['W', 'A', 'S', 'D']
+})
+</script>
+
+<template>
+  <div class="input-hints">
+    <template v-if="activeDevice === 'keyboard'">
+      <span v-for="key in keys" :key="key" class="key">{{ key }}</span>
+    </template>
+    <template v-else>
+      <div class="gamepad-stick" aria-hidden="true" />
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.input-hints {
+  position: absolute;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 0.25rem;
+  pointer-events: none;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.key {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  background: rgba(0, 0, 0, 0.3);
+}
+
+.gamepad-stick {
+  position: relative;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 9999px;
+  background: rgba(0, 0, 0, 0.3);
+}
+
+.gamepad-stick::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.4);
+  transform: translate(-50%, -50%);
+}
+</style>
+

--- a/test/input-hints.test.ts
+++ b/test/input-hints.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import InputHints from '~/components/ui/hud/InputHints.vue'
+
+function mountWithLocale(locale: string) {
+  const i18n = createI18n({ legacy: false, locale, messages: {} })
+  return mount(InputHints, {
+    global: {
+      plugins: [i18n],
+    },
+  })
+}
+
+describe('InputHints', () => {
+  it('renders keyboard keys according to locale', () => {
+    const en = mountWithLocale('en')
+    expect(en.findAll('.key').map(k => k.text())).toEqual(['W', 'A', 'S', 'D'])
+    en.unmount()
+
+    const fr = mountWithLocale('fr')
+    expect(fr.findAll('.key').map(k => k.text())).toEqual(['Z', 'Q', 'S', 'D'])
+  })
+
+  it('switches to gamepad hints when a gamepad connects', async () => {
+    const wrapper = mountWithLocale('en')
+    expect(wrapper.findAll('.key')).toHaveLength(4)
+
+    ;(navigator as any).getGamepads = () => [{ id: 'stub' } as Gamepad]
+    window.dispatchEvent(new Event('gamepadconnected'))
+    await nextTick()
+    expect(wrapper.find('.gamepad-stick').exists()).toBe(true)
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'w' }))
+    await nextTick()
+    expect(wrapper.findAll('.key')).toHaveLength(4)
+  })
+})
+


### PR DESCRIPTION
## Summary
- add minimalist Crosshair HUD component
- add InputHints that adapts to keyboard layout and gamepad
- test InputHints for locale and device switching

## Testing
- `npm test` *(fails: fetch failed for web fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b860bb32a4832aa949f5a390f57c11