### PR TITLE
feat(hud): add crosshair and input hints

### DIFF
--- a/src/components/ui/hud/Crosshair.vue
+++ b/src/components/ui/hud/Crosshair.vue
@@ -1,48 +1,18 @@
 <script setup lang="ts">
 /**
- * Centered minimal crosshair reticle for the heads-up display.
+ * Minimal dual-axis reticle rendered at the center of the screen.
  *
- * Purely visual; emits no events and captures no input.
+ * Purely decorative; it does not react to input or emit events.
  */
 </script>
 
 <template>
-  <div class="crosshair">
-    <div class="line horizontal" />
-    <div class="line vertical" />
+  <div class="absolute top-1/2 left-1/2 h-6 w-6 -translate-x-1/2 -translate-y-1/2 pointer-events-none">
+    <!-- vertical arms -->
+    <span class="absolute top-0 left-1/2 h-2 w-px -translate-x-1/2 bg-white/40" />
+    <span class="absolute bottom-0 left-1/2 h-2 w-px -translate-x-1/2 bg-white/40" />
+    <!-- horizontal arms -->
+    <span class="absolute left-0 top-1/2 h-px w-2 -translate-y-1/2 bg-white/40" />
+    <span class="absolute right-0 top-1/2 h-px w-2 -translate-y-1/2 bg-white/40" />
   </div>
 </template>
-
-<style scoped>
-.crosshair {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 20px;
-  height: 20px;
-  transform: translate(-50%, -50%);
-  pointer-events: none;
-}
-
-.line {
-  position: absolute;
-  background: rgba(255, 255, 255, 0.3);
-}
-
-.horizontal {
-  top: 50%;
-  left: 0;
-  right: 0;
-  height: 1px;
-  transform: translateY(-50%);
-}
-
-.vertical {
-  left: 50%;
-  top: 0;
-  bottom: 0;
-  width: 1px;
-  transform: translateX(-50%);
-}
-</style>
-

--- a/src/components/ui/hud/InputHints.vue
+++ b/src/components/ui/hud/InputHints.vue
@@ -2,36 +2,28 @@
 import { layoutHintFromLocale } from '~/engines/input/utils'
 
 /**
- * Displays movement control hints based on the active input device.
+ * Displays movement control hints for the active input method.
  *
  * Keyboard hints adapt to the user's locale, showing either WASD or ZQSD.
- * When a gamepad is connected, a left-stick icon replaces the keys.
+ * A gamepad connection replaces the keys with a generic left-stick icon.
  */
 const { locale } = useI18n()
 
 const activeDevice = ref<'keyboard' | 'gamepad'>('keyboard')
 
-function handleKeyboard(): void {
+function useKeyboard(): void {
   activeDevice.value = 'keyboard'
 }
 
-function handleGamepad(): void {
+function useGamepad(): void {
   activeDevice.value = 'gamepad'
 }
 
-onMounted(() => {
-  window.addEventListener('keydown', handleKeyboard, { passive: true })
-  window.addEventListener('gamepadconnected', handleGamepad)
-  window.addEventListener('gamepaddisconnected', handleKeyboard)
-})
+useEventListener(window, 'keydown', useKeyboard, { passive: true })
+useEventListener(window, 'gamepadconnected', useGamepad)
+useEventListener(window, 'gamepaddisconnected', useKeyboard)
 
-onUnmounted(() => {
-  window.removeEventListener('keydown', handleKeyboard)
-  window.removeEventListener('gamepadconnected', handleGamepad)
-  window.removeEventListener('gamepaddisconnected', handleKeyboard)
-})
-
-const keys = computed(() => {
+const keys = computed<readonly string[]>(() => {
   if (activeDevice.value !== 'keyboard')
     return []
   const hint = layoutHintFromLocale(locale.value)
@@ -40,59 +32,16 @@ const keys = computed(() => {
 </script>
 
 <template>
-  <div class="input-hints">
+  <div class="pointer-events-none absolute bottom-4 left-1/2 flex -translate-x-1/2 gap-1 text-white/70">
     <template v-if="activeDevice === 'keyboard'">
-      <span v-for="key in keys" :key="key" class="key">{{ key }}</span>
+      <span
+        v-for="key in keys"
+        :key="key"
+        class="key flex h-6 w-6 items-center justify-center rounded border border-white/20 bg-black/30 text-xs"
+      >{{ key }}</span>
     </template>
     <template v-else>
-      <div class="gamepad-stick" aria-hidden="true" />
+      <div class="gamepad-stick i-carbon-game-console text-2xl opacity-70" aria-hidden="true" />
     </template>
   </div>
 </template>
-
-<style scoped>
-.input-hints {
-  position: absolute;
-  bottom: 1rem;
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  gap: 0.25rem;
-  pointer-events: none;
-  color: rgba(255, 255, 255, 0.7);
-}
-
-.key {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.5rem;
-  height: 1.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 0.25rem;
-  font-size: 0.75rem;
-  background: rgba(0, 0, 0, 0.3);
-}
-
-.gamepad-stick {
-  position: relative;
-  width: 1.5rem;
-  height: 1.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 9999px;
-  background: rgba(0, 0, 0, 0.3);
-}
-
-.gamepad-stick::after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 9999px;
-  background: rgba(255, 255, 255, 0.4);
-  transform: translate(-50%, -50%);
-}
-</style>
-


### PR DESCRIPTION
## Summary
- add minimal dual-axis crosshair HUD element
- show movement input hints for keyboard layout or gamepad

## Testing
- `pnpm lint` (fails: Expected "@vue/test-utils" to come before "vitest")
- `pnpm test run`


------
https://chatgpt.com/codex/tasks/task_e_68b8a6ea6130832aa68f0ed6fddae956