### PR TITLE
feat: add FPS demo page with input controls

### DIFF
--- a/src/pages/three-demo-fps.vue
+++ b/src/pages/three-demo-fps.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import DebugOverlay from '~/dev/DebugOverlay.vue'
+import { KeyboardSource } from '~/engines/input/sources/KeyboardSource'
+import { MouseSource } from '~/engines/input/sources/MouseSource'
+import { TouchSource } from '~/engines/input/sources/TouchSource'
+import { GamepadSource } from '~/engines/input/sources/GamepadSource'
+import { Action, type InputSource } from '~/engines/input/types'
+
+const MOUSE_LOOK_SENSITIVITY = 0.002
+const TOUCH_LOOK_SENSITIVITY = 0.002
+const GAMEPAD_LOOK_SENSITIVITY = 0.04
+
+const showDebug = import.meta.env.DEV
+const hasTouch = typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0
+
+const engine = useThreeEngine()
+
+const look = reactive({ x: 0, y: 0 })
+const move = reactive({ x: 0, y: 0 })
+
+const isLocked = ref(false)
+useEventListener(document, 'pointerlockchange', () => {
+  isLocked.value = document.pointerLockElement !== null
+})
+
+const mobileSource: InputSource & {
+  trigger(action: Action, pressed: boolean): void
+} = (() => {
+  let emit: ((action: Action, pressed: boolean) => void) | null = null
+  return {
+    attach(e) {
+      emit = e
+    },
+    detach() {
+      emit = null
+    },
+    poll() {},
+    trigger(action, pressed) {
+      emit?.(action, pressed)
+    },
+  }
+})()
+
+let mouse: MouseSource | undefined
+let touch: TouchSource | undefined
+
+onMounted(() => {
+  const input = engine.getInputEngine()
+
+  input.registerSource(new KeyboardSource())
+  input.registerSource(
+    new GamepadSource({
+      onLook(dx, dy) {
+        look.x += dx * GAMEPAD_LOOK_SENSITIVITY
+        look.y += dy * GAMEPAD_LOOK_SENSITIVITY
+      },
+    }),
+  )
+
+  mouse = new MouseSource()
+  mouse.attach((dx, dy) => {
+    look.x += dx * MOUSE_LOOK_SENSITIVITY
+    look.y += dy * MOUSE_LOOK_SENSITIVITY
+  }, window)
+
+  if (hasTouch) {
+    touch = new TouchSource()
+    touch.attach((dx, dy) => {
+      look.x += dx * TOUCH_LOOK_SENSITIVITY
+      look.y += dy * TOUCH_LOOK_SENSITIVITY
+    }, window)
+    input.registerSource(mobileSource)
+  }
+
+  const baseSnapshot = input.snapshot.bind(input)
+  input.snapshot = () => {
+    const state = baseSnapshot() as any
+    if (look.x !== 0 || look.y !== 0) {
+      state.lookX = look.x
+      state.lookY = look.y
+      look.x = 0
+      look.y = 0
+    }
+    if (hasTouch) {
+      state.moveX = move.x
+      state.moveY = move.y
+    }
+    return state
+  }
+})
+
+onBeforeUnmount(() => {
+  mouse?.detach()
+  touch?.detach()
+})
+
+function handleStick(x: number, y: number): void {
+  move.x = x
+  move.y = -y
+}
+
+function handleJump(pressed: boolean): void {
+  mobileSource.trigger(Action.Jump, pressed)
+}
+function handleInteract(pressed: boolean): void {
+  mobileSource.trigger(Action.Interact, pressed)
+}
+function handleCrouch(pressed: boolean): void {
+  mobileSource.trigger(Action.Crouch, pressed)
+}
+function handleSprint(pressed: boolean): void {
+  mobileSource.trigger(Action.Sprint, pressed)
+}
+</script>
+
+<template>
+  <ThreeCanvas background="#0e0e12">
+    <Ui>
+      <DebugOverlay v-if="showDebug" />
+      <UiHudCrosshair v-if="isLocked || hasTouch" />
+      <UiHudInputHints v-if="isLocked && !hasTouch" />
+      <UiInputVirtualStick
+        v-if="hasTouch"
+        class="absolute left-4 bottom-4"
+        @move="handleStick"
+      />
+      <UiInputActionButtons
+        v-if="hasTouch"
+        class="absolute right-4 bottom-4"
+        @jump="handleJump"
+        @interact="handleInteract"
+        @crouch="handleCrouch"
+        @sprint="handleSprint"
+      />
+      <div
+        v-if="!isLocked && !hasTouch"
+        class="pointer-events-none absolute inset-0 flex items-center justify-center text-white/70"
+      >
+        Click to capture pointer
+      </div>
+    </Ui>
+  </ThreeCanvas>
+</template>

--- a/src/typed-router.d.ts
+++ b/src/typed-router.d.ts
@@ -19,6 +19,7 @@ declare module 'vue-router/auto-routes' {
    */
   export interface RouteNamedMap {
     '/': RouteRecordInfo<'/', '/', Record<never, never>, Record<never, never>>,
+    '/three-demo-fps': RouteRecordInfo<'/three-demo-fps', '/three-demo-fps', Record<never, never>, Record<never, never>>,
   }
 
   /**
@@ -34,6 +35,10 @@ declare module 'vue-router/auto-routes' {
   export interface _RouteFileInfoMap {
     'src/pages/index.vue': {
       routes: '/'
+      views: never
+    }
+    'src/pages/three-demo-fps.vue': {
+      routes: '/three-demo-fps'
       views: never
     }
   }


### PR DESCRIPTION
## Summary
- demo page for FPS interactions with pointer lock, HUD, and mobile controls
- wire input sources into the game engine
- update typed router for new route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8ab72a0f8832a87003efb08cb75a2