### PR TITLE
feat(store): add input settings store

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -251,6 +251,7 @@ declare global {
   const useServerHeadSafe: typeof import('@unhead/vue')['useServerHeadSafe']
   const useServerSeoMeta: typeof import('@unhead/vue')['useServerSeoMeta']
   const useSessionStorage: typeof import('@vueuse/core')['useSessionStorage']
+  const useSettingsInputStore: typeof import('./stores/settings.input')['useSettingsInputStore']
   const useShare: typeof import('@vueuse/core')['useShare']
   const useSlots: typeof import('vue')['useSlots']
   const useSorted: typeof import('@vueuse/core')['useSorted']
@@ -319,6 +320,9 @@ declare global {
   // @ts-ignore
   export type { Component, Slot, Slots, ComponentPublicInstance, ComputedRef, DirectiveBinding, ExtractDefaultPropTypes, ExtractPropTypes, ExtractPublicPropTypes, InjectionKey, PropType, Ref, ShallowRef, MaybeRef, MaybeRefOrGetter, VNode, WritableComputedRef } from 'vue'
   import('vue')
+  // @ts-ignore
+  export type { SprintMode } from './stores/settings.input'
+  import('./stores/settings.input')
 }
 
 // for vue template auto import
@@ -568,6 +572,7 @@ declare module 'vue' {
     readonly useServerHeadSafe: UnwrapRef<typeof import('@unhead/vue')['useServerHeadSafe']>
     readonly useServerSeoMeta: UnwrapRef<typeof import('@unhead/vue')['useServerSeoMeta']>
     readonly useSessionStorage: UnwrapRef<typeof import('@vueuse/core')['useSessionStorage']>
+    readonly useSettingsInputStore: UnwrapRef<typeof import('./stores/settings.input')['useSettingsInputStore']>
     readonly useShare: UnwrapRef<typeof import('@vueuse/core')['useShare']>
     readonly useSlots: UnwrapRef<typeof import('vue')['useSlots']>
     readonly useSorted: UnwrapRef<typeof import('@vueuse/core')['useSorted']>

--- a/src/stores/settings.input.ts
+++ b/src/stores/settings.input.ts
@@ -1,0 +1,49 @@
+import { acceptHMRUpdate, defineStore } from 'pinia'
+
+export type SprintMode = 'hold' | 'toggle'
+
+/**
+ * Store for user input settings.
+ *
+ * Values are persisted to `localStorage` so they survive page reloads.
+ */
+export const useSettingsInputStore = defineStore('settings.input', () => {
+  const sensitivity = useStorage<number>('settings-input-sensitivity', 1)
+  const invertY = useStorage<boolean>('settings-input-invert-y', false)
+  const sprintMode = useStorage<SprintMode>('settings-input-sprint-mode', 'hold')
+  const showHints = useStorage<boolean>('settings-input-show-hints', true)
+
+  function setSensitivity(value: number) {
+    if (!Number.isFinite(value) || value <= 0)
+      throw new Error('Sensitivity must be a positive number')
+    sensitivity.value = value
+  }
+
+  function setInvertY(value: boolean) {
+    invertY.value = value
+  }
+
+  function setSprintMode(mode: SprintMode) {
+    if (mode !== 'hold' && mode !== 'toggle')
+      throw new Error('Invalid sprint mode')
+    sprintMode.value = mode
+  }
+
+  function setShowHints(value: boolean) {
+    showHints.value = value
+  }
+
+  return {
+    sensitivity: readonly(sensitivity),
+    invertY: readonly(invertY),
+    sprintMode: readonly(sprintMode),
+    showHints: readonly(showHints),
+    setSensitivity,
+    setInvertY,
+    setSprintMode,
+    setShowHints,
+  }
+})
+
+if (import.meta.hot)
+  import.meta.hot.accept(acceptHMRUpdate(useSettingsInputStore as any, import.meta.hot))

--- a/test/settings.input.test.ts
+++ b/test/settings.input.test.ts
@@ -1,0 +1,48 @@
+import type { SprintMode } from '~/stores/settings.input'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useSettingsInputStore } from '~/stores/settings.input'
+
+describe('settings input store', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setActivePinia(createPinia())
+  })
+
+  it('exposes defaults and persists updates', async () => {
+    const store = useSettingsInputStore()
+
+    expect(store.sensitivity).toBe(1)
+    expect(store.invertY).toBe(false)
+    expect(store.sprintMode).toBe('hold')
+    expect(store.showHints).toBe(true)
+
+    store.setSensitivity(0.5)
+    store.setInvertY(true)
+    store.setSprintMode('toggle')
+    store.setShowHints(false)
+    await nextTick()
+
+    expect(store.sensitivity).toBe(0.5)
+    expect(store.invertY).toBe(true)
+    expect(store.sprintMode).toBe('toggle')
+    expect(store.showHints).toBe(false)
+
+    setActivePinia(createPinia())
+    const fresh = useSettingsInputStore()
+    expect(fresh.sensitivity).toBe(0.5)
+    expect(fresh.invertY).toBe(true)
+    expect(fresh.sprintMode).toBe('toggle')
+    expect(fresh.showHints).toBe(false)
+  })
+
+  it('rejects invalid sprint mode', () => {
+    const store = useSettingsInputStore()
+    expect(() => store.setSprintMode('invalid' as SprintMode)).toThrow('Invalid sprint mode')
+  })
+
+  it('rejects non-positive sensitivity', () => {
+    const store = useSettingsInputStore()
+    expect(() => store.setSensitivity(0)).toThrow('Sensitivity must be a positive number')
+  })
+})


### PR DESCRIPTION
## Summary
- add Pinia store to persist input sensitivity, invert-Y, sprint mode, and hint visibility
- provide typed getters and mutations for UI binding
- test input settings store persistence and validation

## Testing
- `npm test`
- `npx eslint src/stores/settings.input.ts`
- `npx eslint test/settings.input.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8aec20028832a9226f5c7b626449f