### PR TITLE
test: add input and fps system tests

### DIFF
--- a/test/fps-look-system.test.ts
+++ b/test/fps-look-system.test.ts
@@ -1,0 +1,26 @@
+import { PerspectiveCamera } from 'three'
+import { describe, expect, it } from 'vitest'
+import { FpsCamera } from '~/ecs/components/FpsCamera'
+import { createFpsLookSystem } from '~/ecs/systems/FpsLookSystem'
+import type { InputEngine } from '~/engines/input/InputEngine'
+import type { InputState } from '~/engines/input/types'
+
+describe('FpsLookSystem', () => {
+  it('clamps pitch to component limits', () => {
+    const camera = new FpsCamera({ minPitch: -0.5, maxPitch: 0.5 })
+    const target = new PerspectiveCamera()
+    const inputState: InputState = { actions: {}, lookY: 1 }
+    const input = { snapshot: () => inputState } as unknown as InputEngine
+    const system = createFpsLookSystem({ input, camera, target })
+
+    system(0)
+    expect(camera.pitch).toBe(0.5)
+    expect(target.rotation.x).toBe(0.5)
+
+    inputState.lookY = -2
+    system(0)
+    expect(camera.pitch).toBe(-0.5)
+    expect(target.rotation.x).toBe(-0.5)
+  })
+})
+

--- a/test/fps-move-system.test.ts
+++ b/test/fps-move-system.test.ts
@@ -1,0 +1,45 @@
+import { Object3D } from 'three'
+import { describe, expect, it } from 'vitest'
+import { CharacterController } from '~/ecs/components/CharacterController'
+import { FpsCamera } from '~/ecs/components/FpsCamera'
+import { createFpsMoveSystem } from '~/ecs/systems/FpsMoveSystem'
+import type { InputEngine } from '~/engines/input/InputEngine'
+import { Action } from '~/engines/input/types'
+
+describe('FpsMoveSystem', () => {
+  function createInput(actions: Partial<Record<Action, boolean>>): InputEngine {
+    const state: Record<Action, boolean> = {} as any
+    for (const a of Object.values(Action)) state[a] = false
+    Object.assign(state, actions)
+    return { snapshot: () => ({ actions: state }) } as unknown as InputEngine
+  }
+
+  it('moves forward respecting orientation', () => {
+    const camera = new FpsCamera({ yaw: 0 })
+    const controller = new CharacterController()
+    const target = new Object3D()
+    const input = createInput({ [Action.MoveForward]: true })
+    const system = createFpsMoveSystem({ input, camera, controller, target })
+
+    system(1)
+    expect(target.position.z).toBeCloseTo(5)
+  })
+
+  it('normalises diagonal movement and applies sprint', () => {
+    const camera = new FpsCamera({ yaw: 0 })
+    const controller = new CharacterController()
+    const target = new Object3D()
+    const input = createInput({
+      [Action.MoveForward]: true,
+      [Action.MoveRight]: true,
+      [Action.Sprint]: true,
+    })
+    const system = createFpsMoveSystem({ input, camera, controller, target })
+
+    system(1)
+    const expected = controller.movementSpeed * controller.sprintMultiplier / Math.sqrt(2)
+    expect(target.position.x).toBeCloseTo(expected)
+    expect(target.position.z).toBeCloseTo(expected)
+  })
+})
+

--- a/test/input/fusion.test.ts
+++ b/test/input/fusion.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { InputEngine } from '~/engines/input/InputEngine'
+import { KeyboardSource } from '~/engines/input/sources/KeyboardSource'
+import { MouseSource } from '~/engines/input/sources/MouseSource'
+import { Action } from '~/engines/input/types'
+
+// Utility to toggle pointer lock in tests.
+function setPointerLock(locked: boolean): void {
+  ;(document as any).pointerLockElement = locked ? document.body : null
+  document.dispatchEvent(new Event('pointerlockchange'))
+}
+
+describe('keyboard and mouse fusion', () => {
+  it('merges keyboard actions with inverted mouse look', () => {
+    const engine = new InputEngine()
+    engine.registerSource(new KeyboardSource())
+    engine.start()
+
+    const look = { x: 0, y: 0 }
+    const mouse = new MouseSource({ invertY: true })
+    mouse.attach((dx, dy) => {
+      look.x += dx
+      look.y += dy
+    }, window)
+
+    // integrate look deltas into engine snapshots
+    const baseSnapshot = engine.snapshot.bind(engine)
+    engine.snapshot = () => {
+      const snap = baseSnapshot()
+      mouse.poll()
+      const state: any = { ...snap }
+      if (look.x !== 0 || look.y !== 0) {
+        state.lookX = look.x
+        state.lookY = look.y
+        look.x = 0
+        look.y = 0
+      }
+      return state
+    }
+
+    setPointerLock(true)
+
+    // simulate inputs
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyW' }))
+    const move = new MouseEvent('mousemove')
+    Object.defineProperty(move, 'movementX', { value: 5 })
+    Object.defineProperty(move, 'movementY', { value: 3 })
+    window.dispatchEvent(move)
+
+    const snap = engine.snapshot() as any
+    expect(snap.actions[Action.MoveForward]).toBe(true)
+    expect(snap.lookX).toBe(5)
+    expect(snap.lookY).toBe(-3)
+
+    engine.stop()
+    mouse.detach()
+  })
+})
+

--- a/test/input/gamepad-axes.test.ts
+++ b/test/input/gamepad-axes.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+import { GamepadSource } from '~/engines/input/sources/GamepadSource'
+import { Action } from '~/engines/input/types'
+
+function createGamepad(): Gamepad {
+  const buttons = Array.from({ length: 17 }, () => ({ pressed: false, value: 0, touched: false }))
+  return {
+    axes: [0, 0, 0, 0],
+    buttons: buttons as any,
+    connected: true,
+    id: 'stub',
+    index: 0,
+    mapping: 'standard',
+    timestamp: 0,
+  }
+}
+
+describe('gamepad axes', () => {
+  it('applies deadzone and normalises stick values', () => {
+    const pad = createGamepad()
+    ;(navigator as any).getGamepads = () => [pad]
+
+    const emit = vi.fn()
+    const look = vi.fn()
+    const source = new GamepadSource({ deadzone: 0.2, onLook: look })
+    source.attach(emit)
+
+    const connect = new Event('gamepadconnected') as any
+    connect.gamepad = pad
+    window.dispatchEvent(connect)
+
+    // within deadzone - no action
+    pad.axes[0] = 0.1
+    source.poll()
+    expect(emit).not.toHaveBeenCalled()
+
+    // outside deadzone - action emitted
+    pad.axes[0] = 0.5
+    source.poll()
+    expect(emit).toHaveBeenCalledWith(Action.MoveRight, true)
+
+    // large values are clamped and passed to look callback
+    pad.axes[2] = 2
+    pad.axes[3] = -2
+    source.poll()
+    expect(look).toHaveBeenCalledWith(1, -1)
+
+    source.detach()
+  })
+})
+

--- a/test/input/sprint-mode.test.ts
+++ b/test/input/sprint-mode.test.ts
@@ -1,0 +1,72 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest'
+import { ref, readonly } from 'vue'
+vi.stubGlobal('useStorage', <T>(_key: string, value: T) => ref(value))
+vi.stubGlobal('readonly', readonly)
+import { createPinia, setActivePinia } from 'pinia'
+import { InputEngine } from '~/engines/input/InputEngine'
+import { KeyboardSource } from '~/engines/input/sources/KeyboardSource'
+import { Action } from '~/engines/input/types'
+import { useSettingsInputStore } from '~/stores/settings.input'
+
+function setupEngine(store: ReturnType<typeof useSettingsInputStore>): InputEngine {
+  const engine = new InputEngine()
+  engine.registerSource(new KeyboardSource())
+
+  let sprinting = false
+  engine.onAction(Action.Sprint, pressed => {
+    if (store.sprintMode === 'hold')
+      sprinting = pressed
+    else if (pressed)
+      sprinting = !sprinting
+  })
+
+  const baseSnapshot = engine.snapshot.bind(engine)
+  engine.snapshot = () => {
+    const snap = baseSnapshot()
+    const actions = { ...snap.actions, [Action.Sprint]: sprinting }
+    return { ...snap, actions }
+  }
+
+  engine.start()
+  return engine
+}
+
+describe('sprint modes', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('activates sprint only while held in hold mode', () => {
+    const store = useSettingsInputStore()
+    const engine = setupEngine(store)
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'ShiftLeft' }))
+    let snap = engine.snapshot()
+    expect(snap.actions[Action.Sprint]).toBe(true)
+
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: 'ShiftLeft' }))
+    snap = engine.snapshot()
+    expect(snap.actions[Action.Sprint]).toBe(false)
+
+    engine.stop()
+  })
+
+  it('toggles sprint state in toggle mode', () => {
+    const store = useSettingsInputStore()
+    store.setSprintMode('toggle')
+    const engine = setupEngine(store)
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'ShiftLeft' }))
+    let snap = engine.snapshot()
+    expect(snap.actions[Action.Sprint]).toBe(true)
+
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: 'ShiftLeft' }))
+    engine.snapshot() // process release
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'ShiftLeft' }))
+    snap = engine.snapshot()
+    expect(snap.actions[Action.Sprint]).toBe(false)
+
+    engine.stop()
+  })
+})
+

--- a/test/pointer-lock.test.ts
+++ b/test/pointer-lock.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { usePointerLock } from '~/composables/usePointerLock'
 
 describe('usePointerLock', () => {
   it('handles request and exit and tracks lock state', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import path from 'path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '~/': `${path.resolve(__dirname, 'src')}/`,
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    include: ['test/**/*.test.ts'],
+  },
+})
+


### PR DESCRIPTION
## Summary
- add fused keyboard/mouse input tests with Y inversion and sprint modes
- cover gamepad deadzone, axis normalization, and FPS camera/movement systems
- configure vitest for jsdom and project aliases

## Testing
- `bunx vitest run --config vitest.config.ts test/input/*.test.ts test/fps-look-system.test.ts test/fps-move-system.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b9364f40a4832abfb4c5f45d679f0a