### PR TITLE
feat: wire input axes to fps camera

### DIFF
--- a/src/ecs/systems/FpsLookSystem.ts
+++ b/src/ecs/systems/FpsLookSystem.ts
@@ -18,16 +18,6 @@ export interface FpsLookSystemOptions {
 }
 
 /**
- * Input snapshot extended with optional look deltas.
- */
-interface LookInputState extends InputState {
-  /** Horizontal look delta in radians. */
-  readonly lookX?: number
-  /** Vertical look delta in radians. */
-  readonly lookY?: number
-}
-
-/**
  * Creates a system applying look deltas to a first-person camera.
  *
  * The system consumes `lookX` and `lookY` values from the {@link InputEngine}
@@ -42,7 +32,7 @@ export function createFpsLookSystem(options: FpsLookSystemOptions): System {
   target.rotation.order = 'YXZ'
 
   return () => {
-    const state = input.snapshot() as LookInputState
+    const state: InputState = input.snapshot()
     const dx = state.lookX ?? 0
     const dy = state.lookY ?? 0
     if (dx === 0 && dy === 0)

--- a/src/ecs/systems/FpsMoveSystem.ts
+++ b/src/ecs/systems/FpsMoveSystem.ts
@@ -28,16 +28,6 @@ export interface FpsMoveSystemOptions {
 }
 
 /**
- * Input snapshot extended with optional analogue movement axes.
- */
-interface MoveInputState extends InputState {
-  /** Horizontal movement axis in the range [-1,1]. */
-  readonly moveX?: number
-  /** Vertical movement axis in the range [-1,1]. */
-  readonly moveY?: number
-}
-
-/**
  * Creates a system applying first-person character movement.
  *
  * Movement is derived from `moveX`/`moveY` axes or, when absent, from the
@@ -52,7 +42,7 @@ export function createFpsMoveSystem(options: FpsMoveSystemOptions): System {
   const world = new Vector3()
 
   return (dt: number) => {
-    const state = input.snapshot() as MoveInputState
+    const state: InputState = input.snapshot()
     const { actions } = state
 
     const moveX = state.moveX ?? ((actions[Action.MoveRight] ? 1 : 0) - (actions[Action.MoveLeft] ? 1 : 0))

--- a/src/engines/input/README.md
+++ b/src/engines/input/README.md
@@ -1,30 +1,38 @@
 # Input Engine
 
 The input engine normalises signals from multiple devices (keyboard, gamepad,
-mobile gestures...) into a consistent set of actions. Each frame the engine
-produces an immutable snapshot of the current state allowing systems to safely
-read inputs without risk of mutation.
+mobile gestures...) into a consistent set of actions and analogue axes. Each
+frame the engine produces an immutable snapshot of the current state allowing
+systems to safely read inputs without risk of mutation.
 
 ## Flow
 
 ```
 +-------------+      +---------------+      +-----------------+
-| InputSource | ---> | Input Engine  | ---> | Game Systems    |
+| InputSource | ---> |               |      |                 |
+| LookSource  | ---> | Input Engine  | ---> | Game Systems    |
+| MoveSource  | ---> |               |      |                 |
 +-------------+      +---------------+      +-----------------+
 ```
 
-1. **Sources** translate raw device events into high level {@link Action} values.
+1. **Sources** translate raw device events into high level {@link Action}
+   values and optional analogue axes.
 2. The **engine** aggregates these events, updates its internal state and
    notifies listeners registered via `onAction`.
 3. Systems call `snapshot()` every frame to obtain a frozen
-   {@link InputState} object representing the current actions.
+   {@link InputState} object representing the current actions and axes.
 
 ## API
 
 - `start()` / `stop()` — control all registered sources.
-- `snapshot()` — polls sources and returns the current immutable {@link InputState}.
+- `snapshot()` — polls sources and returns the current immutable
+  {@link InputState}.
 - `onAction(action, cb)` — observe transitions for a specific action.
 - `registerSource(source)` — plug in a new device input translator.
+- `registerLookSource(source)` — add relative look deltas for FPS cameras.
+- `registerMoveSource(source)` — add analogue movement axes.
+- `addLook(dx, dy)` / `addMove(x, y)` — manually feed deltas into the next
+  snapshot.
 
 ## Input Sources
 
@@ -33,6 +41,10 @@ An `InputSource` exposes three methods:
 - `attach(emit)` — begin listening to the underlying device and queue events.
 - `detach()` — remove listeners and clear internal state.
 - `poll()` — flush queued events through the `emit` callback.
+
+`LookSource` and `MoveSource` follow the same structure but emit `(dx, dy)` and
+`(x, y)` values respectively. This keeps the engine extensible while maintaining
+a minimal API surface.
 
 Sources are intentionally decoupled from the engine so new devices can be
 supported without modifying existing logic.

--- a/src/engines/input/sources/MouseSource.ts
+++ b/src/engines/input/sources/MouseSource.ts
@@ -4,7 +4,9 @@
  * Movement is reported via the provided callback when {@link poll} is invoked.
  * Values are accumulated from `mousemove` events and scaled by sensitivity.
  * Optional Y-axis inversion is supported to match user preference.
- */
+*/
+import type { LookSource } from '../types'
+
 export interface MouseSourceOptions {
   /** Scalar applied to movement deltas. */
   readonly sensitivity?: number
@@ -12,7 +14,7 @@ export interface MouseSourceOptions {
   readonly invertY?: boolean
 }
 
-export class MouseSource {
+export class MouseSource implements LookSource {
   private emit: ((deltaX: number, deltaY: number) => void) | null = null
   private target: EventTarget | null = null
   private readonly sensitivity: number

--- a/src/engines/input/sources/TouchSource.ts
+++ b/src/engines/input/sources/TouchSource.ts
@@ -5,7 +5,9 @@
  * is called. Small jitter is ignored using a configurable threshold to avoid
  * unintended camera shake. Default scrolling behaviour is prevented while the
  * source is active.
- */
+*/
+import type { LookSource } from '../types'
+
 export interface TouchSourceOptions {
   /** Multiplier applied to movement deltas. */
   readonly sensitivity?: number
@@ -15,7 +17,7 @@ export interface TouchSourceOptions {
   readonly jitterThreshold?: number
 }
 
-export class TouchSource {
+export class TouchSource implements LookSource {
   private emit: ((deltaX: number, deltaY: number) => void) | null = null
   private target: EventTarget | null = null
   private readonly sensitivity: number

--- a/src/engines/input/types.ts
+++ b/src/engines/input/types.ts
@@ -14,10 +14,21 @@ export enum Action {
 
 /**
  * Immutable snapshot of the user's input for a single frame.
- * All values are boolean flags describing the active state of each action.
+ *
+ * Besides high-level {@link Action} flags the snapshot may include analogue
+ * axes used for smooth first-person camera control and character movement.
  */
 export interface InputState {
-  readonly actions: Readonly<Record<Action, boolean>>;
+  /** Boolean map of active actions. */
+    readonly actions: Readonly<Record<Action, boolean>>;
+  /** Horizontal look delta in radians accumulated this frame. */
+    readonly lookX?: number;
+  /** Vertical look delta in radians accumulated this frame. */
+    readonly lookY?: number;
+  /** Horizontal movement axis in the range [-1,1]. */
+    readonly moveX?: number;
+  /** Vertical movement axis in the range [-1,1]. */
+    readonly moveY?: number;
 }
 
 /**
@@ -27,9 +38,27 @@ export interface InputState {
  */
 export interface InputSource {
   /** Begin listening to the underlying device. */
-  attach(emit: (action: Action, pressed: boolean) => void): void;
+    attach: (emit: (action: Action, pressed: boolean) => void) => void;
   /** Stop listening to the device and release any resources. */
-  detach(): void;
+    detach: () => void;
   /** Flush any queued events and emit resulting action changes. */
-  poll(): void;
+    poll: () => void;
+}
+
+/**
+ * Source emitting relative look deltas for first-person camera control.
+ */
+export interface LookSource {
+    attach: (emit: (deltaX: number, deltaY: number) => void, target?: EventTarget) => void;
+    detach: () => void;
+    poll: () => void;
+}
+
+/**
+ * Source providing analogue movement axes.
+ */
+export interface MoveSource {
+    attach: (emit: (x: number, y: number) => void, target?: EventTarget) => void;
+    detach: () => void;
+    poll: () => void;
 }


### PR DESCRIPTION
## Summary
- extend input engine with look and move sources, enabling FPS camera control
- simplify FPS systems to read analogue axes directly
- demo and tests updated for new input pipeline

## Testing
- `npm test` *(fails: Failed to parse source for import analysis because the content contains invalid JS syntax. Install @vitejs/plugin-vue to handle .vue files.)*
- `npm run lint` *(fails: 151 problems (139 errors, 12 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b93ed00650832abd1bc761c76c4756