### PR TITLE
refactor: defer FPS demo engine setup

### DIFF
--- a/src/components/fps-demo/setup.vue
+++ b/src/components/fps-demo/setup.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { GamepadSource } from '~/engines/input/sources/GamepadSource'
+import { KeyboardSource } from '~/engines/input/sources/KeyboardSource'
+import { MouseSource } from '~/engines/input/sources/MouseSource'
+import { TouchSource } from '~/engines/input/sources/TouchSource'
+import { Action } from '~/engines/input/types'
+import type { InputSource, MoveSource } from '~/engines/input/types'
+
+/**
+ * Registers input sources for the FPS demo and forwards pointer-lock state
+ * to the parent component.
+ */
+const props = defineProps<{ hasTouch: boolean }>()
+const emit = defineEmits<{ 'update:locked': [value: boolean] }>()
+
+const MOUSE_LOOK_SENSITIVITY = 0.002
+const TOUCH_LOOK_SENSITIVITY = 0.002
+const GAMEPAD_LOOK_SENSITIVITY = 0.04
+
+const engine = useThreeEngine()
+const move = reactive({ x: 0, y: 0 })
+
+const isLocked = ref(false)
+useEventListener(document, 'pointerlockchange', () => {
+  const locked = document.pointerLockElement !== null
+  isLocked.value = locked
+  emit('update:locked', locked)
+})
+
+const mobileSource: InputSource & {
+  trigger: (action: Action, pressed: boolean) => void
+} = (() => {
+  let emitAction: ((action: Action, pressed: boolean) => void) | null = null
+  return {
+    attach(e) {
+      emitAction = e
+    },
+    detach() {
+      emitAction = null
+    },
+    poll() {},
+    trigger(action, pressed) {
+      emitAction?.(action, pressed)
+    },
+  }
+})()
+
+let mouse: MouseSource | undefined
+let touch: TouchSource | undefined
+
+onMounted(() => {
+  const input = engine.getInputEngine()
+
+  input.registerSource(new KeyboardSource())
+  input.registerSource(
+    new GamepadSource({
+      onLook(dx, dy) {
+        input.addLook(
+          dx * GAMEPAD_LOOK_SENSITIVITY,
+          dy * GAMEPAD_LOOK_SENSITIVITY,
+        )
+      },
+    }),
+  )
+
+  mouse = new MouseSource({ sensitivity: MOUSE_LOOK_SENSITIVITY })
+  input.registerLookSource(mouse)
+
+  if (props.hasTouch) {
+    touch = new TouchSource({ sensitivity: TOUCH_LOOK_SENSITIVITY })
+    input.registerLookSource(touch)
+    input.registerSource(mobileSource)
+    input.registerMoveSource({
+      emit: null,
+      attach(e) {
+        this.emit = e
+      },
+      detach() {
+        this.emit = null
+      },
+      poll() {
+        this.emit?.(move.x, move.y)
+      },
+    } as MoveSource)
+  }
+})
+
+function handleStick(x: number, y: number): void {
+  move.x = x
+  move.y = -y
+}
+
+function handleJump(pressed: boolean): void {
+  mobileSource.trigger(Action.Jump, pressed)
+}
+function handleInteract(pressed: boolean): void {
+  mobileSource.trigger(Action.Interact, pressed)
+}
+function handleCrouch(pressed: boolean): void {
+  mobileSource.trigger(Action.Crouch, pressed)
+}
+function handleSprint(pressed: boolean): void {
+  mobileSource.trigger(Action.Sprint, pressed)
+}
+
+defineExpose({
+  handleStick,
+  handleJump,
+  handleInteract,
+  handleCrouch,
+  handleSprint,
+})
+</script>
+
+<template />
+

--- a/src/pages/three-demo-fps.vue
+++ b/src/pages/three-demo-fps.vue
@@ -1,97 +1,39 @@
 <script setup lang="ts">
 import DebugOverlay from '~/dev/DebugOverlay.vue'
-import { GamepadSource } from '~/engines/input/sources/GamepadSource'
-import { KeyboardSource } from '~/engines/input/sources/KeyboardSource'
-import { MouseSource } from '~/engines/input/sources/MouseSource'
-import { TouchSource } from '~/engines/input/sources/TouchSource'
-import { Action } from '~/engines/input/types'
-import type { InputSource, MoveSource } from '~/engines/input/types'
-
-const MOUSE_LOOK_SENSITIVITY = 0.002
-const TOUCH_LOOK_SENSITIVITY = 0.002
-const GAMEPAD_LOOK_SENSITIVITY = 0.04
 
 const showDebug = import.meta.env.DEV
 const hasTouch = typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0
 
-const engine = useThreeEngine()
-const move = reactive({ x: 0, y: 0 })
-
 const isLocked = ref(false)
-useEventListener(document, 'pointerlockchange', () => {
-  isLocked.value = document.pointerLockElement !== null
-})
-
-const mobileSource: InputSource & {
-  trigger: (action: Action, pressed: boolean) => void
-} = (() => {
-  let emit: ((action: Action, pressed: boolean) => void) | null = null
-  return {
-    attach: (e) => {
-      emit = e
-    },
-    detach: () => {
-      emit = null
-    },
-    poll: () => {},
-    trigger: (action, pressed) => {
-      emit?.(action, pressed)
-    },
-  }
-})()
-
-let mouse: MouseSource | undefined
-let touch: TouchSource | undefined
-
-onMounted(() => {
-  const input = engine.getInputEngine()
-
-  input.registerSource(new KeyboardSource())
-  input.registerSource(
-    new GamepadSource({
-      onLook(dx, dy) {
-        input.addLook(dx * GAMEPAD_LOOK_SENSITIVITY, dy * GAMEPAD_LOOK_SENSITIVITY)
-      },
-    }),
-  )
-
-  mouse = new MouseSource({ sensitivity: MOUSE_LOOK_SENSITIVITY })
-  input.registerLookSource(mouse)
-
-  if (hasTouch) {
-    touch = new TouchSource({ sensitivity: TOUCH_LOOK_SENSITIVITY })
-    input.registerLookSource(touch)
-    input.registerSource(mobileSource)
-    input.registerMoveSource({
-      emit: null,
-      attach: (e) => { this.emit = e },
-      detach: () => { this.emit = null },
-      poll: () => { this.emit?.(move.x, move.y) },
-    } as MoveSource)
-  }
-})
+const setupRef = ref<{
+  handleStick: (x: number, y: number) => void
+  handleJump: (pressed: boolean) => void
+  handleInteract: (pressed: boolean) => void
+  handleCrouch: (pressed: boolean) => void
+  handleSprint: (pressed: boolean) => void
+} | null>(null)
 
 function handleStick(x: number, y: number): void {
-  move.x = x
-  move.y = -y
+  setupRef.value?.handleStick(x, y)
 }
 
 function handleJump(pressed: boolean): void {
-  mobileSource.trigger(Action.Jump, pressed)
+  setupRef.value?.handleJump(pressed)
 }
 function handleInteract(pressed: boolean): void {
-  mobileSource.trigger(Action.Interact, pressed)
+  setupRef.value?.handleInteract(pressed)
 }
 function handleCrouch(pressed: boolean): void {
-  mobileSource.trigger(Action.Crouch, pressed)
+  setupRef.value?.handleCrouch(pressed)
 }
 function handleSprint(pressed: boolean): void {
-  mobileSource.trigger(Action.Sprint, pressed)
+  setupRef.value?.handleSprint(pressed)
 }
 </script>
 
 <template>
   <ThreeCanvas background="#0e0e12">
+    <FpsDemoSetup ref="setupRef" v-model:locked="isLocked" :has-touch="hasTouch" />
     <Ui>
       <DebugOverlay v-if="showDebug" />
       <UiHudCrosshair v-if="isLocked || hasTouch" />
@@ -118,3 +60,4 @@ function handleSprint(pressed: boolean): void {
     </Ui>
   </ThreeCanvas>
 </template>
+


### PR DESCRIPTION
## Summary
- add FpsDemoSetup component to initialize input sources once ThreeCanvas provides GameEngine
- simplify three-demo-fps page to mount FpsDemoSetup and delegate mobile input handlers

## Testing
- `bun test` *(fails: ReferenceError: window is not defined, missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b94dfbaf8c832aa8f507233f773200