### PR TITLE
feat: align camera defaults

### DIFF
--- a/src/ecs/components/FpsCamera.ts
+++ b/src/ecs/components/FpsCamera.ts
@@ -5,9 +5,9 @@
  * configurable limits to prevent unnatural rotations.
  */
 export interface FpsCameraOptions {
-  /** Initial yaw angle in radians. */
+  /** Initial yaw angle in radians. Defaults to 0 (looking along -Z). */
   yaw?: number
-  /** Initial pitch angle in radians. */
+  /** Initial pitch angle in radians. Defaults to 0 (level). */
   pitch?: number
   /** Lowest allowed pitch angle in radians. Defaults to -\u03c0/2. */
   minPitch?: number

--- a/src/engines/graphics/cameras/MainCamera.ts
+++ b/src/engines/graphics/cameras/MainCamera.ts
@@ -4,8 +4,12 @@ export interface MainCameraOptions {
   fov?: number
   near?: number
   far?: number
+  /** Initial camera position. Defaults to a neutral standing height. */
   position?: Vector3
-  target?: Vector3
+  /** Initial yaw rotation in radians. */
+  yaw?: number
+  /** Initial pitch rotation in radians. */
+  pitch?: number
 }
 
 /**
@@ -16,12 +20,15 @@ export function createMainCamera(options: MainCameraOptions = {}): PerspectiveCa
     fov = 60,
     near = 0.1,
     far = 2000,
-    position = new Vector3(6, 6, 6),
-    target = new Vector3(0, 0, 0),
+    position = new Vector3(0, 1.8, 0),
+    yaw = 0,
+    pitch = 0,
   } = options
 
   const camera = new PerspectiveCamera(fov, 1, near, far)
   camera.position.copy(position)
-  camera.lookAt(target)
+  camera.rotation.order = 'YXZ'
+  camera.rotation.y = yaw
+  camera.rotation.x = pitch
   return camera
 }

--- a/test/fps-camera.test.ts
+++ b/test/fps-camera.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from 'vitest'
 import { FpsCamera } from '~/ecs/components/FpsCamera'
 
 describe('fps camera', () => {
+  it('defaults to neutral yaw and pitch', () => {
+    const camera = new FpsCamera()
+    expect(camera.yaw).toBe(0)
+    expect(camera.pitch).toBe(0)
+  })
+
   it('clamps pitch within provided limits', () => {
     const camera = new FpsCamera({ minPitch: -1, maxPitch: 1 })
     camera.pitch = 2

--- a/test/main-camera.test.ts
+++ b/test/main-camera.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { createMainCamera } from '~/engines/graphics/cameras/MainCamera'
+
+import { Vector3 } from 'three'
+
+describe('main camera', () => {
+  it('initializes at neutral position and orientation', () => {
+    const camera = createMainCamera()
+    expect(camera.position).toEqual(new Vector3(0, 1.8, 0))
+    expect(camera.rotation.y).toBe(0)
+    expect(camera.rotation.x).toBe(0)
+  })
+
+  it('applies provided yaw and pitch', () => {
+    const yaw = Math.PI / 4
+    const pitch = -Math.PI / 6
+    const camera = createMainCamera({ yaw, pitch })
+    expect(camera.rotation.y).toBe(yaw)
+    expect(camera.rotation.x).toBe(pitch)
+  })
+})


### PR DESCRIPTION
## Summary
- start main camera at neutral standing position facing -Z
- document FpsCamera defaults and ensure neutral orientation
- test default camera orientation

## Testing
- `npm test` *(fails: Failed to parse source for import analysis because the content contains invalid JS syntax. Install @vitejs/plugin-vue to handle .vue files)*
- `npx vitest run test/fps-camera.test.ts test/main-camera.test.ts`
- `npm run lint` *(fails: Import in body of module; reorder to top)*
- `npm run typecheck` *(fails: Expected 2 arguments, but got 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d2776f98832a84c1018af7d02019